### PR TITLE
Mirror of awslabs s2n#1066

### DIFF
--- a/tests/unit/s2n_map_test.c
+++ b/tests/unit/s2n_map_test.c
@@ -133,6 +133,26 @@ int main(int argc, char **argv)
     key.size = strlen(keystr) + 1;
     EXPECT_EQUAL(s2n_map_lookup(map, &key, &val), 0);
 
+    /* Make the map mutable */
+    EXPECT_SUCCESS(s2n_map_unlock(map));
+    /* Make sure that add-after-unlock succeeds */
+    EXPECT_SUCCESS(snprintf(keystr, sizeof(keystr), "%04x", 8193));
+    EXPECT_SUCCESS(snprintf(valstr, sizeof(valstr), "%05d", 8193));
+
+    key.data = (void *) keystr;
+    key.size = strlen(keystr) + 1;
+    val.data = (void *) valstr;
+    val.size = strlen(valstr) + 1;
+
+    EXPECT_SUCCESS(s2n_map_add(map, &key, &val));
+
+    /* Complete the map again */
+    EXPECT_SUCCESS(s2n_map_complete(map));
+
+    /* Check the element added after map unlock */
+    EXPECT_EQUAL(s2n_map_lookup(map, &key, &val), 1);
+    EXPECT_SUCCESS(memcmp(val.data, valstr, strlen(valstr) + 1));
+
     EXPECT_SUCCESS(s2n_map_free(map));
 
     END_TEST();

--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -176,6 +176,13 @@ int s2n_map_complete(struct s2n_map *map)
     return 0;
 }
 
+int s2n_map_unlock(struct s2n_map *map)
+{
+    map->immutable = 0;
+
+    return 0;
+}
+
 int s2n_map_lookup(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value)
 {
     S2N_ERROR_IF(!map->immutable, S2N_ERR_MAP_MUTABLE);

--- a/utils/s2n_map.h
+++ b/utils/s2n_map.h
@@ -26,5 +26,6 @@ extern struct s2n_map *s2n_map_new();
 extern int s2n_map_add(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value);
 extern int s2n_map_put(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value);
 extern int s2n_map_complete(struct s2n_map *map);
+extern int s2n_map_unlock(struct s2n_map *map);
 extern int s2n_map_lookup(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value);
 extern int s2n_map_free(struct s2n_map *map);


### PR DESCRIPTION
Mirror of awslabs s2n#1066
Add a function to unlock s2n_map for the use case where lookup and add operations are repeated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

