### PR TITLE
Mirror of awslabs s2n#1064

### DIFF
--- a/pq-crypto/bike/cleanup.h
+++ b/pq-crypto/bike/cleanup.h
@@ -47,6 +47,6 @@ _INLINE_ void compressed_idx_dv_ar_cleanup(IN OUT compressed_idx_dv_ar_t *o)
 {
     for(int i=0; i < N0; i++)
     {
-        secure_clean((uint8_t*)&o[i], sizeof(*o[0])); 
+        secure_clean((uint8_t*)&(*o)[i], sizeof((*o)[0]));
     }
 }


### PR DESCRIPTION
Mirror of awslabs s2n#1064
…ength

**Issue # (if available):** 
N/A

**Description of changes:** 
This fixes the memory issues that other versions of gcc and AddressSanitizer find. The issue was `compressed_idx_dv_ar_cleanup` was attempting to cleanup memory the size of `compressed_idx_dv_ar_t` instead of `compressed_idx_dv_s`. `compressed_idx_dv_ar_t` is an array of 2 `compressed_idx_dv_s`, this code now cleans the `compressed_idx_dv_s` and uses the size of `compressed_idx_dv_ar_t[0]` which is `compressed_idx_dv_s` instead of the total size for both. When the loop gets to the second one it now no longer goes past the end by the extra `compressed_idx_dv_s`.

This change now passes the new fuzz tests for BIKE but I'm still tweaking the timeout/speed of the BIKE tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

