### PR TITLE
Mirror of awslabs s2n#1063

### DIFF
--- a/tests/unit/s2n_self_talk_test.c
+++ b/tests/unit/s2n_self_talk_test.c
@@ -108,7 +108,6 @@ int main(int argc, char **argv)
     char *cert_chain_pem;
     char *private_key_pem;
     char *dhparams_pem;
-    struct s2n_cert_chain_and_key *chain_and_key;
 
     BEGIN_TEST();
     EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
@@ -117,85 +116,89 @@ int main(int argc, char **argv)
 
     EXPECT_SUCCESS(setenv("S2N_ENABLE_CLIENT_MODE", "1", 0));
 
-    for (int cert = 0; cert < SUPPORTED_CERTIFICATE_FORMATS; cert++) {
-        for (int is_dh_key_exchange = 0; is_dh_key_exchange <= 1; is_dh_key_exchange++) {
-            /* Create a pipe */
-            EXPECT_SUCCESS(pipe(server_to_client));
-            EXPECT_SUCCESS(pipe(client_to_server));
+    for (int is_dh_key_exchange = 0; is_dh_key_exchange <= 1; is_dh_key_exchange++) {
+        struct s2n_cert_chain_and_key *chain_and_keys[SUPPORTED_CERTIFICATE_FORMATS];
 
-            /* Create a child process */
-            pid = fork();
-            if (pid == 0) {
-                /* This is the child process, close the read end of the pipe */
-                EXPECT_SUCCESS(close(client_to_server[0]));
-                EXPECT_SUCCESS(close(server_to_client[1]));
+        /* Create a pipe */
+        EXPECT_SUCCESS(pipe(server_to_client));
+        EXPECT_SUCCESS(pipe(client_to_server));
 
-                /* Write the fragmented hello message */
-                mock_client(client_to_server[1], server_to_client[0]);
-            }
+        /* Create a child process */
+        pid = fork();
+        if (pid == 0) {
+            /* This is the child process, close the read end of the pipe */
+            EXPECT_SUCCESS(close(client_to_server[0]));
+            EXPECT_SUCCESS(close(server_to_client[1]));
 
-            /* This is the parent */
-            EXPECT_SUCCESS(close(client_to_server[1]));
-            EXPECT_SUCCESS(close(server_to_client[0]));
+            /* Write the fragmented hello message */
+            mock_client(client_to_server[1], server_to_client[0]);
+        }
 
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-            conn->server_protocol_version = S2N_TLS12;
-            conn->client_protocol_version = S2N_TLS12;
-            conn->actual_protocol_version = S2N_TLS12;
+        /* This is the parent */
+        EXPECT_SUCCESS(close(client_to_server[1]));
+        EXPECT_SUCCESS(close(server_to_client[0]));
 
-            EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        conn->server_protocol_version = S2N_TLS12;
+        conn->client_protocol_version = S2N_TLS12;
+        conn->actual_protocol_version = S2N_TLS12;
 
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        for (int cert = 0; cert < SUPPORTED_CERTIFICATE_FORMATS; cert++) {
             EXPECT_SUCCESS(s2n_read_test_pem(certificate_paths[cert], cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
             EXPECT_SUCCESS(s2n_read_test_pem(private_key_paths[cert], private_key_pem, S2N_MAX_TEST_PEM_SIZE));
-            EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
-            EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
-            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-            if (is_dh_key_exchange) {
-                EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_DHPARAMS, dhparams_pem, S2N_MAX_TEST_PEM_SIZE));
-                EXPECT_SUCCESS(s2n_config_add_dhparams(config, dhparams_pem));
-            }
-
-            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
-
-            /* Set up the connection to read from the fd */
-            EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
-            EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
-
-            /* Negotiate the handshake. */
-            EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
-
-            char buffer[0xffff];
-            for (int i = 1; i < 0xffff; i += 100) {
-                char * ptr = buffer;
-                int size = i;
-
-                do {
-                    int bytes_read = 0;
-                    EXPECT_SUCCESS(bytes_read = s2n_recv(conn, ptr, size, &blocked));
-
-                    size -= bytes_read;
-                    ptr += bytes_read;
-                } while(size);
-
-                for (int j = 0; j < i; j++) {
-                    EXPECT_EQUAL(buffer[j], 33);
-                }
-            }
-
-            int shutdown_rc = -1;
-            do {
-                shutdown_rc = s2n_shutdown(conn, &blocked);
-                EXPECT_TRUE(shutdown_rc == 0 || (errno == EAGAIN && blocked));
-            } while(shutdown_rc != 0);
-
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
-            EXPECT_SUCCESS(s2n_config_free(config));
-
-            /* Clean up */
-            EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
-            EXPECT_EQUAL(status, 0);
+            EXPECT_NOT_NULL(chain_and_keys[cert] = s2n_cert_chain_and_key_new());
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_keys[cert], cert_chain_pem, private_key_pem));
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_keys[cert]));
         }
+
+        if (is_dh_key_exchange) {
+            EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_DHPARAMS, dhparams_pem, S2N_MAX_TEST_PEM_SIZE));
+            EXPECT_SUCCESS(s2n_config_add_dhparams(config, dhparams_pem));
+        }
+
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        /* Set up the connection to read from the fd */
+        EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, client_to_server[0]));
+        EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, server_to_client[1]));
+
+        /* Negotiate the handshake. */
+        EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
+
+        char buffer[0xffff];
+        for (int i = 1; i < 0xffff; i += 100) {
+            char * ptr = buffer;
+            int size = i;
+
+            do {
+                int bytes_read = 0;
+                EXPECT_SUCCESS(bytes_read = s2n_recv(conn, ptr, size, &blocked));
+
+                size -= bytes_read;
+                ptr += bytes_read;
+            } while(size);
+
+            for (int j = 0; j < i; j++) {
+                EXPECT_EQUAL(buffer[j], 33);
+            }
+        }
+
+        int shutdown_rc = -1;
+        do {
+            shutdown_rc = s2n_shutdown(conn, &blocked);
+            EXPECT_TRUE(shutdown_rc == 0 || (errno == EAGAIN && blocked));
+        } while(shutdown_rc != 0);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        for (int cert = 0; cert < SUPPORTED_CERTIFICATE_FORMATS; cert++) {
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_keys[cert]));
+        }
+        EXPECT_SUCCESS(s2n_config_free(config));
+
+        /* Clean up */
+        EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
+        EXPECT_EQUAL(status, 0);
     }
 
     free(cert_chain_pem);

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -165,13 +165,14 @@ int s2n_conn_update_required_handshake_hashes(struct s2n_connection *conn)
  */
 int s2n_conn_find_name_matching_certs(struct s2n_connection *conn)
 {
-    if (!s2n_server_received_server_name(conn)) {
+    struct s2n_array *certs = conn->config->cert_and_key_pairs;
+    const uint32_t num_certs = s2n_array_num_elements(certs);
+    if (!s2n_server_received_server_name(conn) || num_certs < 2) {
         return 0;
     }
 
     const char *name = conn->server_name;
-    struct s2n_array *certs = conn->config->cert_and_key_pairs;
-    for (int i = 0; i < s2n_array_num_elements(certs); i++) {
+    for (int i = 0; i < num_certs; i++) {
         struct s2n_cert_chain_and_key *chain_and_key = *((struct s2n_cert_chain_and_key**) s2n_array_get(certs, i));
         s2n_authentication_method auth_method = s2n_cert_chain_and_key_get_auth_method(chain_and_key);
         /* Add the match if there isn't already an existing match for the certificate key type */


### PR DESCRIPTION
Mirror of awslabs s2n#1063
Avoid spending extra computation matching a certificate with a domain
name if there aren't multiple choices.

This change is meant to accommodate use cases where the application only configures a single certificate or the application runs their own certificate selection logic in the `client_hello_callback`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

