### PR TITLE
Mirror of awslabs s2n#1070

### DIFF
--- a/tests/testlib/s2n_kem_tests.c
+++ b/tests/testlib/s2n_kem_tests.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/s2n_kem.h"
+#include "tests/unit/s2n_nist_kats.h"
+#include "utils/s2n_mem.h"
+#include "utils/s2n_random.h"
+#include "utils/s2n_safety.h"
+
+/*
+ * These values are taken from BIKE which currently uses the most memory. These may need to be raised when new PQ KEMS
+ * are added.
+ */
+#define MAX_PRIVATE_KEY_LENGTH  4670
+#define MAX_PUBLIC_KEY_LENGTH  2542
+#define MAX_CIPHERTEXT_LENGTH 2542
+#define MAX_SHARED_SECRET_LENGTH 32
+#define MAX_SEED_LENGTH 48
+uint8_t kat_entropy_buff[MAX_SEED_LENGTH] = {0};
+struct s2n_blob kat_entropy_blob = {.size = 48, .data = kat_entropy_buff};
+
+int kat_entropy(struct s2n_blob *blob)
+{
+    eq_check(blob->size, kat_entropy_blob.size);
+    blob->data = kat_entropy_blob.data;
+    return 0;
+}
+
+int s2n_test_kem_with_kat(const struct s2n_kem *kem, const char *kat_file_name)
+{
+    notnull_check(kem);
+    lte_check(kem->public_key_length, MAX_PUBLIC_KEY_LENGTH);
+    lte_check(kem->private_key_length, MAX_PRIVATE_KEY_LENGTH);
+    lte_check(kem->ciphertext_length, MAX_CIPHERTEXT_LENGTH);
+    lte_check(kem->shared_secret_key_length, MAX_SHARED_SECRET_LENGTH);
+
+    FILE *kat_file = fopen(kat_file_name, "r");
+    notnull_check(kat_file);
+
+    int count = 0;
+
+    /* Client side variables */
+    uint8_t ct[MAX_CIPHERTEXT_LENGTH];
+    uint8_t client_shared_secret[MAX_SHARED_SECRET_LENGTH];
+
+    /* Server side variables */
+    uint8_t pk[MAX_PUBLIC_KEY_LENGTH];
+    uint8_t sk[MAX_PRIVATE_KEY_LENGTH];
+    uint8_t server_shared_secret[MAX_SHARED_SECRET_LENGTH];
+
+    /* Known answer variables */
+    uint8_t pk_answer[MAX_PUBLIC_KEY_LENGTH];
+    uint8_t sk_answer[MAX_PRIVATE_KEY_LENGTH];
+    uint8_t ct_answer[MAX_CIPHERTEXT_LENGTH];
+    uint8_t ss_answer[MAX_SHARED_SECRET_LENGTH];
+
+    s2n_stack_blob(persoanlization_string, 48, 48);
+
+    for (uint32_t i = 0; i < NUM_OF_KATS; i++) {
+        /* Verify test index */
+        GUARD(FindMarker(kat_file, "count = "));
+        gt_check(fscanf(kat_file, "%d", &count), 0);
+        eq_check(count, i);
+
+        /* Set the NIST rng to the same state the response file was created with */
+        GUARD(ReadHex(kat_file, kat_entropy_blob.data, 48, "seed = "));
+        struct s2n_drbg kat_drbg = {.entropy_generator = kat_entropy};
+        GUARD(s2n_drbg_instantiate(&kat_drbg, &persoanlization_string, S2N_DANGEROUS_AES_256_CTR_NO_DF_NO_PR));
+        GUARD(s2n_set_private_drbg_for_test(kat_drbg));
+
+        /* Generate the public/private key pair */
+        GUARD(kem->generate_keypair(pk, sk));
+
+        /* Create a shared secret and use the public key to encrypt it */
+        GUARD(kem->encapsulate(ct, client_shared_secret, pk));
+
+        /* Use the private key to decrypt the ct to get the shared secret */
+        GUARD(kem->decapsulate(server_shared_secret, ct, sk));
+
+        /* Read the KAT values */
+        GUARD(ReadHex(kat_file, pk_answer, kem->public_key_length, "pk = "));
+        GUARD(ReadHex(kat_file, sk_answer, kem->private_key_length, "sk = "));
+        GUARD(ReadHex(kat_file, ct_answer, kem->ciphertext_length, "ct = "));
+        GUARD(ReadHex(kat_file, ss_answer, kem->shared_secret_key_length, "ss = "));
+
+        /* Test the client and server got the same value */
+        eq_check(memcmp( client_shared_secret, server_shared_secret, kem->shared_secret_key_length ), 0);
+
+        /* Compare the KAT values */
+        eq_check(memcmp(pk_answer, pk, kem->shared_secret_key_length), 0);
+        eq_check(memcmp(sk_answer, sk, kem->shared_secret_key_length), 0);
+        eq_check(memcmp(ct_answer, ct, kem->shared_secret_key_length), 0);
+        eq_check(memcmp(ss_answer, server_shared_secret, kem->shared_secret_key_length ), 0);
+    }
+    fclose(kat_file);
+
+    return 0;
+}

--- a/tests/testlib/s2n_testlib.h
+++ b/tests/testlib/s2n_testlib.h
@@ -102,3 +102,5 @@ int s2n_read_test_pem(const char *pem_path, char *pem_out, long int max_size);
 
 int s2n_negotiate_test_server_and_client(struct s2n_connection *server_conn, struct s2n_connection *client_conn);
 int s2n_shutdown_test_server_and_client(struct s2n_connection *server_conn, struct s2n_connection *client_conn);
+
+int s2n_test_kem_with_kat(const struct s2n_kem *kem, const char *kat_file);

--- a/tests/unit/s2n_bike1_l1_kat_test.c
+++ b/tests/unit/s2n_bike1_l1_kat_test.c
@@ -17,101 +17,19 @@
  * Copyright © 2017 Bassham, Lawrence E (Fed). All rights reserved.
  */
 
-#include "s2n_test.h"
-#include "crypto/s2n_drbg.h"
-#include "pq-crypto/bike/bike1_l1_kem.h"
-#include "pq-crypto/pq_random.h"
-#include "tests/unit/s2n_nist_kats.h"
-#include "utils/s2n_mem.h"
-#include "utils/s2n_safety.h"
-#include "utils/s2n_random.h"
 #include "crypto/s2n_fips.h"
+#include "s2n_test.h"
+#include "tests/testlib/s2n_testlib.h"
+#include "tls/s2n_kem.h"
 
-#define RSP_FILE_NAME "kats/bike1_l1.kat"
-
-struct s2n_blob kat_entropy_blob = {0};
-
-int kat_entropy(struct s2n_blob *blob)
-{
-    eq_check(blob->size, kat_entropy_blob.size);
-    blob->data = kat_entropy_blob.data;
-    return 0;
-}
+#define RSP_FILE "kats/bike1_l1.kat"
 
 int main(int argc, char **argv, char **envp) {
     BEGIN_TEST();
-
-    // BIKE is not supported in FIPS mode
     if (s2n_is_in_fips_mode()) {
+        /* Skip when FIPS mode is set as BIKE is not supported in FIPS mode */
         END_TEST();
     }
-
-    FILE *kat_file = fopen(RSP_FILE_NAME, "r");
-    EXPECT_NOT_NULL(kat_file);
-
-    int count;
-    EXPECT_SUCCESS(s2n_alloc(&kat_entropy_blob, 48));
-
-    // Client side variables
-    uint8_t ct[BIKE1_L1_CIPHERTEXT_BYTES];
-    uint8_t client_shared_secret[BIKE1_L1_SHARED_SECRET_BYTES];
-
-    // Server side variables
-    uint8_t pk[BIKE1_L1_PUBLIC_KEY_BYTES];
-    uint8_t sk[BIKE1_L1_SECRET_KEY_BYTES];
-    uint8_t server_shared_secret[BIKE1_L1_SHARED_SECRET_BYTES];
-
-    // Known answer variables
-    uint8_t pk_answer[BIKE1_L1_PUBLIC_KEY_BYTES];
-    uint8_t sk_answer[BIKE1_L1_SECRET_KEY_BYTES];
-    uint8_t ct_answer[BIKE1_L1_CIPHERTEXT_BYTES];
-    uint8_t shared_secret_answer[BIKE1_L1_SHARED_SECRET_BYTES];
-
-    s2n_stack_blob(persoanlization_string, 48, 48);
-
-    for (uint32_t i = 0; i < NUM_OF_KATS; i++) {
-        // Verify test index
-        EXPECT_SUCCESS(FindMarker(kat_file, "count = "));
-        EXPECT_TRUE(fscanf(kat_file, "%d", &count) > 0);
-        EXPECT_EQUAL(count, i);
-
-        // Set the NIST rng to the same state the response file was created with
-        EXPECT_SUCCESS(ReadHex(kat_file, kat_entropy_blob.data, 48, "seed = "));
-        struct s2n_drbg kat_drbg = {.entropy_generator = kat_entropy};
-        EXPECT_SUCCESS(s2n_drbg_instantiate(&kat_drbg, &persoanlization_string, S2N_DANGEROUS_AES_256_CTR_NO_DF_NO_PR));
-        EXPECT_SUCCESS(s2n_set_private_drbg_for_test(kat_drbg));
-        ////////////////////////////////////
-        //      Run the protocol
-        ////////////////////////////////////
-        // Generate the public/private key pair
-        EXPECT_SUCCESS(BIKE1_L1_crypto_kem_keypair(pk, sk));
-
-        // Create a shared secret and use the public key to encrypt it
-        EXPECT_SUCCESS(BIKE1_L1_crypto_kem_enc(ct, client_shared_secret, pk));
-
-        // Use the private key to decrypt the ct to get the shared secret
-        EXPECT_SUCCESS(BIKE1_L1_crypto_kem_dec(server_shared_secret, ct, sk));
-
-        ////////////////////////////////////
-        //      Verify the results
-        ////////////////////////////////////
-        // Read the KAT values
-        EXPECT_SUCCESS(ReadHex(kat_file, pk_answer, BIKE1_L1_PUBLIC_KEY_BYTES, "pk = "));
-        EXPECT_SUCCESS(ReadHex(kat_file, sk_answer, BIKE1_L1_SECRET_KEY_BYTES, "sk = "));
-        EXPECT_SUCCESS(ReadHex(kat_file, ct_answer, BIKE1_L1_CIPHERTEXT_BYTES, "ct = "));
-        EXPECT_SUCCESS(ReadHex(kat_file, shared_secret_answer, BIKE1_L1_SHARED_SECRET_BYTES, "ss = "));
-
-        // Test the client and server got the same value
-        EXPECT_BYTEARRAY_EQUAL(client_shared_secret, server_shared_secret, BIKE1_L1_SHARED_SECRET_BYTES);
-
-        // Compare the KAT values
-        EXPECT_BYTEARRAY_EQUAL(pk_answer, pk, BIKE1_L1_PUBLIC_KEY_BYTES);
-        EXPECT_BYTEARRAY_EQUAL(sk_answer, sk, BIKE1_L1_SECRET_KEY_BYTES);
-        EXPECT_BYTEARRAY_EQUAL(ct_answer, ct, BIKE1_L1_CIPHERTEXT_BYTES);
-        EXPECT_BYTEARRAY_EQUAL(shared_secret_answer, server_shared_secret, BIKE1_L1_SHARED_SECRET_BYTES);
-    }
-
-    fclose(kat_file);
-
+    EXPECT_SUCCESS(s2n_test_kem_with_kat(&s2n_bike_supported_params[0], RSP_FILE));
     END_TEST();
 }

--- a/tests/unit/s2n_sike_p503_kat_test.c
+++ b/tests/unit/s2n_sike_p503_kat_test.c
@@ -18,97 +18,13 @@
  */
 
 #include "s2n_test.h"
-#include "crypto/s2n_drbg.h"
-#include "pq-crypto/sike/sike_p503_kem.h"
-#include "pq-crypto/pq_random.h"
-#include "tests/unit/s2n_nist_kats.h"
-#include "utils/s2n_mem.h"
-#include "utils/s2n_safety.h"
-#include "utils/s2n_random.h"
+#include "tests/testlib/s2n_testlib.h"
+#include "tls/s2n_kem.h"
 
-#define RSP_FILE_NAME "kats/sike_p503.kat"
-
-struct s2n_blob kat_entropy_blob = {0};
-
-int kat_entropy(struct s2n_blob *blob)
-{
-    eq_check(blob->size, kat_entropy_blob.size);
-    blob->data = kat_entropy_blob.data;
-    return 0;
-}
+#define RSP_FILE "kats/sike_p503.kat"
 
 int main(int argc, char **argv, char **envp) {
     BEGIN_TEST();
-
-    FILE *kat_file = fopen(RSP_FILE_NAME, "r");
-    EXPECT_NOT_NULL(kat_file);
-
-    int count;
-    EXPECT_SUCCESS(s2n_alloc(&kat_entropy_blob, 48));
-
-    // Client side variables
-    uint8_t ct[SIKE_P503_CIPHERTEXT_BYTES];
-    uint8_t client_shared_secret[SIKE_P503_SHARED_SECRET_BYTES];
-
-    // Server side variables
-    uint8_t pk[SIKE_P503_PUBLIC_KEY_BYTES];
-    uint8_t sk[SIKE_P503_SECRET_KEY_BYTES];
-    uint8_t server_shared_secret[SIKE_P503_SHARED_SECRET_BYTES];
-
-    // Known answer variables
-    uint8_t pk_answer[SIKE_P503_PUBLIC_KEY_BYTES];
-    uint8_t sk_answer[SIKE_P503_SECRET_KEY_BYTES];
-    uint8_t ct_answer[SIKE_P503_CIPHERTEXT_BYTES];
-    uint8_t shared_secret_answer[SIKE_P503_SHARED_SECRET_BYTES];
-
-    s2n_stack_blob(persoanlization_string, 48, 48);
-
-    for (uint32_t i = 0; i < NUM_OF_KATS; i++) {
-        // Verify test index
-        EXPECT_SUCCESS(FindMarker(kat_file, "count = "));
-        EXPECT_TRUE(fscanf(kat_file, "%d", &count) > 0);
-        EXPECT_EQUAL(count, i);
-
-        // Set the NIST rng to the same state the response file was created with
-        EXPECT_SUCCESS(ReadHex(kat_file, kat_entropy_blob.data, 48, "seed = "));
-        struct s2n_drbg kat_drbg = {.entropy_generator = kat_entropy};
-        EXPECT_SUCCESS(s2n_drbg_instantiate(&kat_drbg, &persoanlization_string, S2N_DANGEROUS_AES_256_CTR_NO_DF_NO_PR));
-        EXPECT_SUCCESS(s2n_set_private_drbg_for_test(kat_drbg));
-
-        ////////////////////////////////////
-        //      Run the protocol
-        ////////////////////////////////////
-
-        // Generate the public/private key pair
-        EXPECT_SUCCESS(SIKE_P503_crypto_kem_keypair(pk, sk));
-
-        // Create a shared secret and use the public key to encrypt it
-        EXPECT_SUCCESS(SIKE_P503_crypto_kem_enc(ct, client_shared_secret, pk));
-
-        // Use the private key to decrypt the ct to get the shared secret
-        EXPECT_SUCCESS(SIKE_P503_crypto_kem_dec(server_shared_secret, ct, sk));
-
-        ////////////////////////////////////
-        //      Verify the results
-        ////////////////////////////////////
-
-        // Read the KAT values
-        EXPECT_SUCCESS(ReadHex(kat_file, pk_answer, SIKE_P503_PUBLIC_KEY_BYTES, "pk = "));
-        EXPECT_SUCCESS(ReadHex(kat_file, sk_answer, SIKE_P503_SECRET_KEY_BYTES, "sk = "));
-        EXPECT_SUCCESS(ReadHex(kat_file, ct_answer, SIKE_P503_CIPHERTEXT_BYTES, "ct = "));
-        EXPECT_SUCCESS(ReadHex(kat_file, shared_secret_answer, SIKE_P503_SHARED_SECRET_BYTES, "ss = "));
-
-        // Test the client and server got the same value
-        EXPECT_BYTEARRAY_EQUAL(client_shared_secret, server_shared_secret, SIKE_P503_SHARED_SECRET_BYTES);
-
-        // Compare the KAT values
-        EXPECT_BYTEARRAY_EQUAL(pk_answer, pk, SIKE_P503_PUBLIC_KEY_BYTES);
-        EXPECT_BYTEARRAY_EQUAL(sk_answer, sk, SIKE_P503_SECRET_KEY_BYTES);
-        EXPECT_BYTEARRAY_EQUAL(ct_answer, ct, SIKE_P503_CIPHERTEXT_BYTES);
-        EXPECT_BYTEARRAY_EQUAL(shared_secret_answer, server_shared_secret, SIKE_P503_SHARED_SECRET_BYTES);
-    }
-
-    fclose(kat_file);
-
+    EXPECT_SUCCESS(s2n_test_kem_with_kat(&s2n_sike_supported_params[0], RSP_FILE));
     END_TEST();
 }

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+#include "pq-crypto/bike/bike1_l1_kem.h"
 #include "pq-crypto/sike/sike_p503_kem.h"
 
 #include "stuffer/s2n_stuffer.h"
@@ -33,6 +34,19 @@ const struct s2n_kem s2n_sike_supported_params[1] = {
                 .generate_keypair = &SIKE_P503_crypto_kem_keypair,
                 .encapsulate = &SIKE_P503_crypto_kem_enc,
                 .decapsulate = &SIKE_P503_crypto_kem_dec,
+        },
+};
+
+const struct s2n_kem s2n_bike_supported_params[1] = {
+        {
+                .kem_extension_id = BIKE1r1_Level1,
+                .public_key_length = BIKE1_L1_PUBLIC_KEY_BYTES,
+                .private_key_length = BIKE1_L1_SECRET_KEY_BYTES,
+                .shared_secret_key_length = BIKE1_L1_SHARED_SECRET_BYTES,
+                .ciphertext_length = BIKE1_L1_CIPHERTEXT_BYTES,
+                .generate_keypair = &BIKE1_L1_crypto_kem_keypair,
+                .encapsulate = &BIKE1_L1_crypto_kem_enc,
+                .decapsulate = &BIKE1_L1_crypto_kem_dec,
         },
 };
 

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -43,6 +43,7 @@ struct s2n_kem_keypair {
 };
 
 extern const struct s2n_kem s2n_sike_supported_params[1];
+extern const struct s2n_kem s2n_bike_supported_params[1];
 
 extern int s2n_kem_generate_keypair(struct s2n_kem_keypair *kem_keys);
 

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -61,6 +61,7 @@
 /* TLS Hybrid post-quantum definitions from https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid-01 */
 #define TLS_ECDHE_SIKE_RSA_WITH_AES_256_GCM_SHA384 0xFF, 0x08
 #define TLS_EXTENSION_PQ_KEM_PARAMETERS 0xFE01
+#define BIKE1r1_Level1 1
 #define SIKEp503r1_KEM 10
 
 /* From https://tools.ietf.org/html/rfc7507 */


### PR DESCRIPTION
Mirror of awslabs s2n#1070
**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/904
**Description of changes:** 
Both tests were basically the same except for the specific KEM methods and response file. This simplifies that so adding additional KEMS requires less boilerplate code. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

