### PR TITLE
Mirror of awslabs s2n#1077

### DIFF
--- a/tests/unit/s2n_rfc5952_test.c
+++ b/tests/unit/s2n_rfc5952_test.c
@@ -40,6 +40,10 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_inet_ntop(AF_INET, ipv4, &ipv4_blob));
     EXPECT_EQUAL(strcmp("0.0.0.0", (char *) ipv4_buf), 0);
 
+    EXPECT_SUCCESS(inet_pton(AF_INET, "100.104.123.1", ipv4));
+    EXPECT_SUCCESS(s2n_inet_ntop(AF_INET, ipv4, &ipv4_blob));
+    EXPECT_EQUAL(strcmp("100.104.123.1", (char *) ipv4_buf), 0);
+
     EXPECT_SUCCESS(inet_pton(AF_INET, "255.255.255.255", ipv4));
     EXPECT_SUCCESS(s2n_inet_ntop(AF_INET, ipv4, &ipv4_blob));
     EXPECT_EQUAL(strcmp("255.255.255.255", (char *) ipv4_buf), 0);

--- a/utils/s2n_rfc5952.c
+++ b/utils/s2n_rfc5952.c
@@ -36,7 +36,7 @@ int s2n_inet_ntop(int af, const void *addr, struct s2n_blob *dst)
             if (bytes[i] / 100) {
                 *cursor++ = dec[bytes[i] / 100];
             }
-            if ((bytes[i] % 100) / 10) {
+            if (bytes[i] >= 10) {
                 *cursor++ = dec[(bytes[i] % 100) / 10];
             }
             *cursor++ = dec[(bytes[i] % 10)];


### PR DESCRIPTION
Mirror of awslabs s2n#1077
**Issue:** #1076

**Description of changes:** 
This adds the special case that was not handled correctly before to the unit test for ntop, and fixes ntop to handle bytes between 100 and 109 correctly.

Without the change to `s12n_rfc5952.c`, the adjusted unit test fails, because the IP is formatted as `10.14.123.1` by `s2n_inet_ntop`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

