### PR TITLE
Mirror of awslabs s2n#1101

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -253,9 +253,9 @@ extern int s2n_connection_get_server_protocol_version(struct s2n_connection *con
 extern int s2n_connection_get_actual_protocol_version(struct s2n_connection *conn);
 extern int s2n_connection_get_client_hello_version(struct s2n_connection *conn);
 extern int s2n_connection_client_cert_used(struct s2n_connection *conn);
-extern const char *s2n_connection_get_cipher(struct s2n_connection *conn);
+extern const char *s2n_connection_get_cipher_name(struct s2n_connection *conn);
 extern int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, const char *version);
-extern const char *s2n_connection_get_curve(struct s2n_connection *conn);
+extern const char *s2n_connection_get_curve_name(struct s2n_connection *conn);
 extern const char *s2n_connection_get_kem_name(struct s2n_connection *conn);
 extern int s2n_connection_get_alert(struct s2n_connection *conn);
 

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -84,7 +84,7 @@ int negotiate(struct s2n_connection *conn)
         printf("Application protocol: %s\n", s2n_get_application_protocol(conn));
     }
 
-    printf("Curve: %s\n", s2n_connection_get_curve(conn));
+    printf("Curve: %s\n", s2n_connection_get_curve_name(conn));
     printf("KEM: %s\n", s2n_connection_get_kem_name(conn));
 
     uint32_t length;
@@ -93,7 +93,7 @@ int negotiate(struct s2n_connection *conn)
         fprintf(stderr, "OCSP response received, length %u\n", length);
     }
 
-    printf("Cipher negotiated: %s\n", s2n_connection_get_cipher(conn));
+    printf("Cipher negotiated: %s\n", s2n_connection_get_cipher_name(conn));
     if (s2n_connection_is_session_resumed(conn)) {
         printf("Resumed session\n");
     }

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1257,19 +1257,19 @@ TLS alerts fatal and shuts down a connection whenever one is received.
 ### s2n\_connection\_get\_cipher
 
 ```c
-const char * s2n_connection_get_cipher(struct s2n_connection *conn);
+const char * s2n_connection_get_cipher_name(struct s2n_connection *conn);
 ```
 
-**s2n_connection_get_cipher** returns a string indicating the cipher suite
+**s2n_connection_get_cipher_name** returns a string indicating the cipher suite
 negotiated by s2n for a connection in Openssl format, e.g. "ECDHE-RSA-AES128-GCM-SHA256".
 
 ### s2n\_connection\_get\_curve
 
 ```c
-const char * s2n_connection_get_curve(struct s2n_connection *conn);
+const char * s2n_connection_get_curve_name(struct s2n_connection *conn);
 ```
 
-**s2n_connection_get_curve** returns a string indicating the elliptic curve used during ECDHE key exchange. The string "NONE" is returned if no curve has was used.
+**s2n_connection_get_curve_name** returns a string indicating the elliptic curve used during ECDHE key exchange. The string "NONE" is returned if no curve has was used.
 
 ### s2n\_connection\_get\_selected\_cert
 

--- a/tests/unit/s2n_connection_context_test.c
+++ b/tests/unit/s2n_connection_context_test.c
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_connection_free(conn));
 
     /* Verify that we don't assume nonnull input and seg fault */
-    EXPECT_NULL(s2n_connection_get_cipher(conn_null));
+    EXPECT_NULL(s2n_connection_get_cipher_name(conn_null));
 
     END_TEST();
 }

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -147,7 +147,7 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
 
         if (!expect_failure) {
             GUARD(try_handshake(server_conn, client_conn));
-            const char* actual_cipher = s2n_connection_get_cipher(server_conn);
+            const char* actual_cipher = s2n_connection_get_cipher_name(server_conn);
             if (strcmp(actual_cipher, expected_cipher->name) != 0){
                 return -1;
             }

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -835,7 +835,7 @@ uint64_t s2n_connection_get_wire_bytes_out(struct s2n_connection *conn)
     return conn->wire_bytes_out;
 }
 
-const char *s2n_connection_get_cipher(struct s2n_connection *conn)
+const char *s2n_connection_get_cipher_name(struct s2n_connection *conn)
 {
     notnull_check_ptr(conn);
     notnull_check_ptr(conn->secure.cipher_suite);
@@ -843,7 +843,7 @@ const char *s2n_connection_get_cipher(struct s2n_connection *conn)
     return conn->secure.cipher_suite->name;
 }
 
-const char *s2n_connection_get_curve(struct s2n_connection *conn)
+const char *s2n_connection_get_curve_name(struct s2n_connection *conn)
 {
     notnull_check_ptr(conn);
 


### PR DESCRIPTION
Mirror of awslabs s2n#1101
…me to make it clear it is the name not the actually curve struct or cipher struct

**Issue # (if available):** 
https://github.com/awslabs/s2n/issues/434
**Description of changes:** 
When adding `s2n_connection_get_kem_name` I noticed these were slightly confusing. They return the name not the entire struct. Before declaring 1.0 we can take this time to rename them. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

