### PR TITLE
Mirror of awslabs s2n#1099

### DIFF
--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -131,6 +131,7 @@ typedef enum {
     S2N_ERR_MAP_DUPLICATE,
     S2N_ERR_MAP_IMMUTABLE,
     S2N_ERR_MAP_MUTABLE,
+    S2N_ERR_MAP_INVALID_MAP_SIZE,
     S2N_ERR_INITIAL_HMAC,
     S2N_ERR_INVALID_NONCE_TYPE,
     S2N_ERR_UNIMPLEMENTED,
@@ -191,3 +192,4 @@ extern __thread const char *s2n_debug_str;
 #define S2N_ERROR( x )      do { _S2N_ERROR( ( x ) ); return -1; } while (0)
 #define S2N_ERROR_PTR( x )  do { _S2N_ERROR( ( x ) ); return NULL; } while (0)
 #define S2N_ERROR_IF( cond , x ) do { if ( cond ) { S2N_ERROR( x ); }} while (0)
+#define S2N_ERROR_IF_PTR( cond , x ) do { if ( cond ) { S2N_ERROR_PTR( x ); }} while (0)

--- a/tests/fuzz/s2n_client_cert_verify_recv_test.c
+++ b/tests/fuzz/s2n_client_cert_verify_recv_test.c
@@ -143,8 +143,9 @@ int LLVMFuzzerInitialize(const uint8_t *buf, size_t len)
     GUARD(s2n_config_add_cert_chain_and_key(server_config, certificate_chain, private_key));
 
     s2n_cert_type cert_type;
-    struct s2n_array *certs = server_config->cert_and_key_pairs;
-    struct s2n_cert_chain_and_key *cert = *((struct s2n_cert_chain_and_key**) s2n_array_get(certs, 0));
+    S2N_ERROR_IF(s2n_config_get_num_default_certs(server_config) == 0, S2N_ERR_NUM_DEFAULT_CERTIFICATES);
+    struct s2n_cert_chain_and_key *cert = s2n_config_get_single_default_cert(server_config);
+    notnull_check(cert);
     GUARD(s2n_asn1der_to_public_key_and_type(&public_key, &cert_type, &cert->cert_chain->head->raw));
 
     return 0;

--- a/tests/unit/s2n_map_test.c
+++ b/tests/unit/s2n_map_test.c
@@ -57,7 +57,11 @@ int main(int argc, char **argv)
     /* Done with the empty map */
     EXPECT_SUCCESS(s2n_map_free(empty));
 
-    EXPECT_NOT_NULL(map = s2n_map_new());
+    /* Expect failure since initial map size is zero */
+    EXPECT_NULL(map = s2n_map_new_with_initial_capacity(0));
+
+    /* Create map with the smallest initial size */
+    EXPECT_NOT_NULL(map = s2n_map_new_with_initial_capacity(1));
 
     /* Insert 8k key value pairs of the form hex(i) -> dec(i) */
     for (int i = 0; i < 8192; i++) {

--- a/tls/s2n_client_cert_request.c
+++ b/tls/s2n_client_cert_request.c
@@ -29,9 +29,10 @@
 
 static int s2n_set_cert_chain_as_client(struct s2n_connection *conn)
 {
-    struct s2n_array *certs = conn->config->cert_and_key_pairs;
-    if (s2n_array_num_elements(certs) > 0) {
-        conn->handshake_params.our_chain_and_key = *((struct s2n_cert_chain_and_key**) s2n_array_get(certs, 0));
+    if (s2n_config_get_num_default_certs(conn->config) > 0) {
+        struct s2n_cert_chain_and_key *cert = s2n_config_get_single_default_cert(conn->config);
+        notnull_check(cert);
+        conn->handshake_params.our_chain_and_key = cert;
     }
 
     return 0;

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -122,7 +122,7 @@ static int s2n_config_init(struct s2n_config *config)
     }
 
     notnull_check(config->cert_and_key_pairs = s2n_array_new(sizeof(struct s2n_cert_chain_and_key*)));
-    notnull_check(config->domain_name_to_cert_map = s2n_map_new());
+    notnull_check(config->domain_name_to_cert_map = s2n_map_new_with_initial_capacity(1));
     GUARD(s2n_map_complete(config->domain_name_to_cert_map));
     memset(&config->default_cert_per_auth_method, 0, sizeof(struct auth_method_to_cert_value));
     config->default_certs_are_explicit = 0;

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -35,7 +35,6 @@ struct s2n_config {
      * used to release memory allocated only in the deprecated API that the application 
      * does not have a reference to. */
     unsigned cert_allocated:1;
-    struct s2n_array *cert_and_key_pairs;
     struct s2n_map *domain_name_to_cert_map;
     unsigned default_certs_are_explicit:1;
     struct auth_method_to_cert_value default_cert_per_auth_method;
@@ -105,3 +104,5 @@ extern int s2n_config_free_session_ticket_keys(struct s2n_config *config);
 
 extern void s2n_wipe_static_configs(void);
 int s2n_config_get_cert_type(struct s2n_config *config, s2n_cert_type *cert_type);
+extern struct s2n_cert_chain_and_key *s2n_config_get_single_default_cert(struct s2n_config *config);
+extern int s2n_config_get_num_default_certs(struct s2n_config *config);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -487,7 +487,7 @@ int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *co
     }
 
     /* We only support one client certificate */
-    if (s2n_array_num_elements(config->cert_and_key_pairs) > 1 && conn->mode == S2N_CLIENT) {
+    if (s2n_config_get_num_default_certs(config) > 1 && conn->mode == S2N_CLIENT) {
         S2N_ERROR(S2N_ERR_TOO_MANY_CERTIFICATES);
     }
 

--- a/utils/s2n_map.h
+++ b/utils/s2n_map.h
@@ -23,6 +23,7 @@
 struct s2n_map;
 
 extern struct s2n_map *s2n_map_new();
+extern struct s2n_map *s2n_map_new_with_initial_capacity(uint32_t capacity);
 extern int s2n_map_add(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value);
 extern int s2n_map_put(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value);
 extern int s2n_map_complete(struct s2n_map *map);


### PR DESCRIPTION
Mirror of awslabs s2n#1099
This change reduces the memory usage for certificate loading and domain name lookup. Change includes:

 - Make s2n_map initial capacity configurable and also make s2n_map work with initial size of 1 and 2
 - Set the initial map capacity for cert loading and lookup to 1 so that the map has only single map entry for a single cert use case
 - Remove s2n_array data structure previously used for cert loading from s2n_config 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

