### PR TITLE
Mirror of awslabs s2n#1098

### DIFF
--- a/tests/saw/s2n_handshake_io.saw
+++ b/tests/saw/s2n_handshake_io.saw
@@ -283,7 +283,7 @@ let s2n_advance_message_spec = do {
     crucible_return (crucible_term {{ 0 : [32] }});
 };
 
-// Specs for the 4 functions that s2n_advance_message calls. Right now
+// Specs for the 5 functions that s2n_advance_message calls. Right now
 // we just assume the specs and don't verify them. That's because we
 // don't model the state that they depend on, instead, making assumptions
 // about it: we use managed corking and the socket was initially uncorked.
@@ -351,6 +351,17 @@ let s2n_socket_was_corked_spec = do {
 };
 
 
+// Specification for s2n_socket_quickack. This is essentially
+// a noop function that returns 0 from the perspective of our current proof
+let s2n_socket_quickack_spec = do {
+    pconn <- crucible_alloc (llvm_struct "struct.s2n_connection");
+
+    crucible_execute_func [pconn];
+
+    crucible_return (crucible_term {{ 0 : [32] }});
+};
+
+
 // Specification for s2n_connection_is_managed_corked. We assume it
 // always returns 1 to reflect our assumption that the library is
 // managing the corking and uncorking of the socket. Otherwise, the
@@ -384,6 +395,8 @@ let s2n_handshake_io_lowlevel = do {
     s2n_socket_write_cork <- crucible_llvm_unsafe_assume_spec llvm "s2n_socket_write_cork" s2n_socket_write_cork_spec;
     print "s2n_socket_was_corked";
     s2n_socket_was_corked <- crucible_llvm_unsafe_assume_spec llvm "s2n_socket_was_corked" s2n_socket_was_corked_spec;
+    print "s2n_socket_quickack";
+    s2n_socket_quickack <- crucible_llvm_unsafe_assume_spec llvm "s2n_socket_quickack" s2n_socket_quickack_spec;
     print "s2n_connection_is_managed_corked";
     s2n_connection_is_managed_corked <- crucible_llvm_unsafe_assume_spec llvm "s2n_connection_is_managed_corked" s2n_connection_is_managed_corked_spec;
     print "s2n_generate_new_client_session_id";
@@ -392,7 +405,7 @@ let s2n_handshake_io_lowlevel = do {
     s2n_allowed_to_cache_connection <- crucible_llvm_unsafe_assume_spec llvm "s2n_allowed_to_cache_connection" s2n_allowed_to_cache_connection_spec;
     print "s2n_decrypt_session_ticket";
     s2n_decrypt_session_ticket <- crucible_llvm_unsafe_assume_spec llvm "s2n_decrypt_session_ticket" s2n_decrypt_session_ticket_spec;
-    let dependencies = [s2n_socket_write_uncork, s2n_socket_write_cork, s2n_socket_was_corked, s2n_connection_is_managed_corked];
+    let dependencies = [s2n_socket_write_uncork, s2n_socket_write_cork, s2n_socket_was_corked, s2n_connection_is_managed_corked, s2n_socket_quickack];
 
 
     print "Proving correctness of get_auth_type";

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -260,6 +260,10 @@ static int s2n_advance_message(struct s2n_connection *conn)
 
     /* Actually advance the message number */
     conn->handshake.message_number++;
+
+    /* Set TCP_QUICKACK to avoid artificial dealy during the handshake */
+    GUARD(s2n_socket_quickack(conn));
+
     /* If optimized io hasn't been enabled or if the caller started out with a corked socket,
      * we don't mess with it
      */

--- a/utils/s2n_socket.c
+++ b/utils/s2n_socket.c
@@ -37,6 +37,28 @@
     #define S2N_CORK_OFF    1
 #endif
 
+int s2n_socket_quickack(struct s2n_connection *conn)
+{
+#ifdef TCP_QUICKACK
+    if (!conn->managed_io) {
+        return 0;
+    }
+
+    struct s2n_socket_read_io_context *r_io_ctx = (struct s2n_socket_read_io_context *) conn->recv_io_context;
+    if (r_io_ctx->tcp_quickack_set) {
+        return 0;
+    }
+
+    /* Ignore the return value, if it fails it fails */
+    int optval = 1;
+    if (setsockopt(r_io_ctx->fd, IPPROTO_TCP, TCP_QUICKACK, &optval, sizeof(optval)) == 0) {
+        r_io_ctx->tcp_quickack_set = 1;
+    }
+#endif
+
+    return 0;
+}
+
 int s2n_socket_write_snapshot(struct s2n_connection *conn)
 {
 #ifdef S2N_CORK
@@ -164,6 +186,9 @@ int s2n_socket_read(void *io_context, uint8_t *buf, uint32_t len)
         errno = EBADF;
         return -1;
     }
+
+    /* Clear the quickack flag so we know to reset it */
+    ((struct s2n_socket_read_io_context*) io_context)->tcp_quickack_set = 0;
 
     /* On success, the number of bytes read is returned. On failure, -1 is
      * returned and errno is set appropriately. */

--- a/utils/s2n_socket.h
+++ b/utils/s2n_socket.h
@@ -22,6 +22,8 @@ struct s2n_socket_read_io_context {
     /* The peer's fd */
     int fd;
 
+    /* Has TCP_QUICKACK been set since the last read */
+    unsigned int tcp_quickack_set:1;
     /* Original SO_RCVLOWAT socket option settings before s2n takes over the fd */
     unsigned int original_rcvlowat_is_set:1;
     int original_rcvlowat_val;
@@ -37,6 +39,7 @@ struct s2n_socket_write_io_context {
     int original_cork_val;
 };
 
+extern int s2n_socket_quickack(struct s2n_connection *conn);
 extern int s2n_socket_read_snapshot(struct s2n_connection *conn);
 extern int s2n_socket_write_snapshot(struct s2n_connection *conn);
 extern int s2n_socket_read_restore(struct s2n_connection *conn);


### PR DESCRIPTION
Mirror of awslabs s2n#1098
**Issue # (if available):** #979 

**Description of changes:** 

The Nagle algorithm can add artifical delay during the TLS handshake by delaying ACKs.  By setting TCP_QUICKACK as we advance through the handshake state machine means we will not incur the delay penalty and will decrease overall handshake latency

Testing between two instances, I was able to capture a tcpdump between s2nc and s2nd.  Without TCP_QUICKACK the handshake took 84ms.  With TCP_QUICKACK the handshake took 5ms.

Closes #979 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

