### PR TITLE
Mirror of awslabs s2n#1143

### DIFF
--- a/.travis/install_shellcheck.sh
+++ b/.travis/install_shellcheck.sh
@@ -28,7 +28,7 @@ fi
 TRAVIS_PLATFORM=$1
 
 if [ "$TRAVIS_PLATFORM" == "linux" ]; then
-    which shellcheck || sudo apt-get -qq update && sudo apt-get -qq install shellcheck -y
+    which shellcheck || (sudo apt-get -qq update && sudo apt-get -qq install shellcheck -y)
 elif [ "$TRAVIS_PLATFORM" == "osx" ]; then
     # Installing an existing package is a "failure" in brew
     brew install shellcheck || true ;


### PR DESCRIPTION
Mirror of awslabs s2n#1143
**Issue # (if available):** 
bad operator precedence introduced in #1126, causing travis builds to fail

**Description of changes:** 

previously,
```
a || b && c
```

we expected the line to complete if a is true. unfortunately, bash interprets 
```
(a || b) && c
```

and c fails, so the fix is 
```
a || (b && c)
```

where a is checking shellcheck, b is updating apt, c is installing shellcheck

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

