### PR TITLE
Mirror of awslabs s2n#1149

### DIFF
--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -827,7 +827,6 @@ struct {
     { .version="ELBSecurityPolicy-FS-2018-06", .preferences=&elb_security_policy_fs_2018_06, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="ELBSecurityPolicy-FS-1-2-2019-08", .preferences=&elb_security_policy_fs_1_2_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0}, 
     { .version="ELBSecurityPolicy-FS-1-1-2019-08", .preferences=&elb_security_policy_fs_1_1_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0}, 
-    { .version="ELBSecurityPolicy-FS-Res-2019-08", .preferences=&elb_security_policy_fs_Res_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0}, 
     { .version="ELBSecurityPolicy-FS-1-2-Res-2019-08", .preferences=&elb_security_policy_fs_1_2_Res_2019_08, .ecc_extension_required=0, .pq_kem_extension_required=0}, 
     { .version="CloudFront-Upstream", .preferences=&cipher_preferences_cloudfront_upstream, .ecc_extension_required=0, .pq_kem_extension_required=0},
     { .version="CloudFront-SSL-v-3", .preferences=&cipher_preferences_cloudfront_ssl_v_3, .ecc_extension_required=0, .pq_kem_extension_required=0},

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -594,23 +594,6 @@ const struct s2n_cipher_preferences elb_security_policy_fs_1_1_2019_08 = {
     .minimum_protocol_version = S2N_TLS11,
 };
 
-struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_Res_2019_08[] = {
-    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
-    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
-    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
-    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
-    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
-    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
-    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
-    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
-};
-
-const struct s2n_cipher_preferences elb_security_policy_fs_Res_2019_08 = {
-    .count = sizeof(cipher_suites_elb_security_policy_fs_Res_2019_08) / sizeof(cipher_suites_elb_security_policy_fs_Res_2019_08[0]), 
-    .suites = cipher_suites_elb_security_policy_fs_Res_2019_08, 
-    .minimum_protocol_version = S2N_TLS10,
-};
-
 struct s2n_cipher_suite *cipher_suites_elb_security_policy_fs_1_2_Res_2019_08[] = {
     &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -53,7 +53,6 @@ extern const struct s2n_cipher_preferences elb_security_policy_fs_2018_06;
 
 extern const struct s2n_cipher_preferences elb_security_policy_fs_1_2_2019_08;
 extern const struct s2n_cipher_preferences elb_security_policy_fs_1_1_2019_08;
-extern const struct s2n_cipher_preferences elb_security_policy_fs_res_2019_08;
 extern const struct s2n_cipher_preferences elb_security_policy_fs_1_2_res_2019_08;
 
 extern int s2n_cipher_preferences_init();


### PR DESCRIPTION
Mirror of awslabs s2n#1149
**Issue # (if available):** 

In one of my previous [pull request](https://github.com/awslabs/s2n/pull/1113), one elb security policy (ELBSecurityPolicy-FS-Res-2019-08) has inconsistent cipher suites and TLS policy. This pull request removed this policy for hygiene reason.

**Description of changes:** 

Removed codes related to ```ELBSecurityPolicy-FS-Res-2019-08``` policy.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

