### PR TITLE
Mirror of awslabs s2n#1161

### DIFF
--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -26,6 +26,7 @@
 #include <s2n.h>
 
 #include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_client_hello.h"
 #include "tls/s2n_handshake.h"
@@ -87,7 +88,7 @@ int main(int argc, char **argv)
 
         /* When TLS 1.3 supported */
         {
-            EXPECT_SUCCESS(setenv("S2N_ENABLE_TLS13_FOR_TESTING", "1", 0));
+            EXPECT_SUCCESS(s2n_enable_tls13());
 
             struct s2n_config *config;
             EXPECT_NOT_NULL(config = s2n_config_new());
@@ -123,7 +124,7 @@ int main(int argc, char **argv)
             }
 
             EXPECT_SUCCESS(s2n_config_free(config));
-            EXPECT_SUCCESS(unsetenv("S2N_ENABLE_TLS13_FOR_TESTING"));
+            EXPECT_SUCCESS(s2n_disable_tls13());
         }
     }
 

--- a/tests/unit/s2n_client_supported_versions_extension_test.c
+++ b/tests/unit/s2n_client_supported_versions_extension_test.c
@@ -21,6 +21,7 @@
 #include "tls/s2n_config.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
 #include "tls/extensions/s2n_client_supported_versions.h"
 
 #include "stuffer/s2n_stuffer.h"
@@ -49,7 +50,8 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    EXPECT_SUCCESS(setenv("S2N_ENABLE_TLS13_FOR_TESTING", "1", 0));
+    EXPECT_SUCCESS(s2n_enable_tls13());
+
     uint8_t latest_version = S2N_TLS13;
 
     struct s2n_config *config;

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -16,12 +16,19 @@
 #include "s2n_test.h"
 
 #include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
 #include "tls/s2n_config.h"
 #include "tls/s2n_connection.h"
+#include "tls/s2n_client_extensions.h"
+
+static uint8_t tls13_extensions[] = { TLS_EXTENSION_SUPPORTED_VERSIONS, TLS_EXTENSION_KEY_SHARE };
 
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
+
+    /* TLS 1.3 is not enabled by default */
+    EXPECT_FALSE(s2n_is_tls13_enabled());
 
     /* Client does not use TLS 1.3 by default */
     {
@@ -43,7 +50,41 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    EXPECT_SUCCESS(setenv("S2N_ENABLE_TLS13_FOR_TESTING", "1", 0));
+    /* Server does not parse new TLS 1.3 extensions by default */
+    {
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+        struct s2n_stuffer extension_data;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extension_data, 0));
+        EXPECT_SUCCESS(s2n_stuffer_write_str(&extension_data, "bad extension"));
+
+        uint8_t original_data_size = s2n_stuffer_data_available(&extension_data);
+
+        struct s2n_array *extensions = s2n_array_new(sizeof(struct s2n_client_hello_parsed_extension*));
+        for (int i=0; i < sizeof(tls13_extensions) / sizeof(uint8_t); i++) {
+            struct s2n_client_hello_parsed_extension *extension;
+            EXPECT_NOT_NULL(extension = s2n_array_add(extensions));
+
+            extension->extension = extension_data.blob;
+            extension->extension_type = tls13_extensions[i];
+        }
+
+        EXPECT_SUCCESS(s2n_client_extensions_recv(server_conn, extensions));
+        /* None of the extensions parsed any data */
+        EXPECT_EQUAL(original_data_size, s2n_stuffer_data_available(&extension_data));
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension_data));
+        EXPECT_SUCCESS(s2n_array_free(extensions));
+    }
+
+    EXPECT_SUCCESS(s2n_enable_tls13());
+    EXPECT_TRUE(s2n_is_tls13_enabled());
+
+    /* Re-enabling has no effect */
+    EXPECT_SUCCESS(s2n_enable_tls13());
+    EXPECT_TRUE(s2n_is_tls13_enabled());
 
     /* Client does use TLS 1.3 if enabled */
     {
@@ -64,6 +105,43 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
+
+    /* Server does parse new TLS 1.3 extensions if enabled */
+    {
+        uint8_t new_extensions[] = { TLS_EXTENSION_SUPPORTED_VERSIONS, TLS_EXTENSION_KEY_SHARE };
+
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+        struct s2n_stuffer extension_data;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extension_data, 0));
+
+        struct s2n_array *extensions = s2n_array_new(sizeof(struct s2n_client_hello_parsed_extension*));
+        struct s2n_client_hello_parsed_extension *extension;
+        EXPECT_NOT_NULL(extension = s2n_array_add(extensions));
+
+        for (int i=0; i < sizeof(new_extensions) / sizeof(uint8_t); i++) {
+            EXPECT_SUCCESS(s2n_stuffer_wipe(&extension_data));
+            EXPECT_SUCCESS(s2n_stuffer_write_str(&extension_data, "bad extension"));
+
+            extension->extension_type = new_extensions[i];
+            extension->extension = extension_data.blob;
+
+            /* We're not passing in well-formed extensions, so if they are parsed then they should fail */
+            EXPECT_FAILURE(s2n_client_extensions_recv(server_conn, extensions));
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension_data));
+        EXPECT_SUCCESS(s2n_array_free(extensions));
+    }
+
+    EXPECT_SUCCESS(s2n_disable_tls13());
+    EXPECT_FALSE(s2n_is_tls13_enabled());
+
+    /* Re-disabling has no effect */
+    EXPECT_SUCCESS(s2n_disable_tls13());
+    EXPECT_FALSE(s2n_is_tls13_enabled());
 
     END_TEST();
     return 0;

--- a/tls/s2n_client_extensions.c
+++ b/tls/s2n_client_extensions.c
@@ -32,6 +32,7 @@
 #include "stuffer/s2n_stuffer.h"
 
 #include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
 #include "utils/s2n_safety.h"
 #include "utils/s2n_blob.h"
 
@@ -289,10 +290,14 @@ int s2n_client_extensions_recv(struct s2n_connection *conn, struct s2n_array *pa
             GUARD(s2n_recv_pq_kem_extension(conn, &extension));
             break;
         case TLS_EXTENSION_SUPPORTED_VERSIONS:
-            GUARD(s2n_extensions_client_supported_versions_recv(conn, &extension));
+            if ( s2n_is_tls13_enabled() ) {
+                GUARD(s2n_extensions_client_supported_versions_recv(conn, &extension));
+            }
             break;
         case TLS_EXTENSION_KEY_SHARE:
-            GUARD(s2n_extensions_client_key_share_recv(conn, &extension));
+            if ( s2n_is_tls13_enabled() ) {
+                GUARD(s2n_extensions_client_key_share_recv(conn, &extension));
+            }
             break;
         }
     }

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -22,6 +22,7 @@
 #include "crypto/s2n_fips.h"
 
 #include "tls/s2n_cipher_preferences.h"
+#include "tls/s2n_tls13.h"
 #include "utils/s2n_safety.h"
 #include "crypto/s2n_hkdf.h"
 #include "utils/s2n_map.h"
@@ -121,7 +122,7 @@ static int s2n_config_init(struct s2n_config *config)
         s2n_config_set_cipher_preferences(config, "default_fips");
     }
 
-    if (getenv("S2N_ENABLE_TLS13_FOR_TESTING") != NULL && S2N_IN_TEST ) {
+    if ( s2n_is_tls13_enabled() ) {
         s2n_config_set_cipher_preferences(config, "default_tls13");
     }
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -687,18 +687,10 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     /* Require all handshakes hashes. This set can be reduced as the handshake progresses. */
     GUARD(s2n_handshake_require_all_hashes(&conn->handshake));
 
-    uint8_t s2n_initial_protocol_version = s2n_highest_protocol_version;
-
-    /* TLS 1.3 is not fully supported yet, and only available for developmental testing.
-     * TLS 1.2 should still be used outside of tests. */
-    if (getenv("S2N_ENABLE_TLS13_FOR_TESTING") != NULL && S2N_IN_TEST ) {
-        s2n_initial_protocol_version = S2N_TLS13;
-    }
-
     if (conn->mode == S2N_SERVER) {
         /* Start with the highest protocol version so that the highest common protocol version can be selected */
         /* during handshake. */
-        conn->server_protocol_version = s2n_initial_protocol_version;
+        conn->server_protocol_version = s2n_highest_protocol_version;
         conn->client_protocol_version = s2n_unknown_protocol_version;
         conn->actual_protocol_version = s2n_unknown_protocol_version;
     }
@@ -706,8 +698,8 @@ int s2n_connection_wipe(struct s2n_connection *conn)
         /* For clients, also set actual_protocol_version.  Record generation uses that value for the initial */
         /* ClientHello record version. Not all servers ignore the record version in ClientHello. */
         conn->server_protocol_version = s2n_unknown_protocol_version;
-        conn->client_protocol_version = s2n_initial_protocol_version;
-        conn->actual_protocol_version = s2n_initial_protocol_version;
+        conn->client_protocol_version = s2n_highest_protocol_version;
+        conn->actual_protocol_version = s2n_highest_protocol_version;
     }
 
     return 0;

--- a/tls/s2n_tls13.c
+++ b/tls/s2n_tls13.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
+
+int s2n_is_tls13_enabled()
+{
+    return s2n_highest_protocol_version == S2N_TLS13;
+}
+
+int s2n_enable_tls13()
+{
+    s2n_highest_protocol_version = S2N_TLS13;
+    return 0;
+}
+
+int s2n_disable_tls13()
+{
+    s2n_highest_protocol_version = S2N_TLS12;
+    return 0;
+}

--- a/tls/s2n_tls13.h
+++ b/tls/s2n_tls13.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+int s2n_is_tls13_enabled();
+int s2n_enable_tls13();
+int s2n_disable_tls13();


### PR DESCRIPTION
Mirror of awslabs s2n#1161
All new extensions should be gated, just to avoid unexpected
issues in production before we've finished and tested 1.3.

This change was motivated by finding a problem where the new
supported versions extension can break RSA key exchange when
the client supports TLS1.3 but negotiates down to TLS1.2 and
tries to use RSA key exchange.

**Issue # (if available):** 

**Description of changes:** 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

