### PR TITLE
Mirror of awslabs s2n#1501

### DIFF
--- a/tests/unit/s2n_self_talk_min_protocol_version.c
+++ b/tests/unit/s2n_self_talk_min_protocol_version.c
@@ -41,7 +41,7 @@ int mock_client(int writefd, int readfd)
     s2n_connection_set_config(client_conn, client_config);
     s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING);
 
-    /* Force TLSv1 on a client so that server fail handshake */
+    /* Force TLSv1 on a client so that server will fail handshake */
     client_conn->client_protocol_version = S2N_TLS10;
 
     s2n_connection_set_read_fd(client_conn, readfd);

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -172,13 +172,16 @@ static int s2n_parse_client_hello(struct s2n_connection *conn)
     GUARD(s2n_stuffer_erase_and_read_bytes(in, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
     GUARD(s2n_stuffer_read_uint8(in, &conn->session_id_len));
 
-    conn->client_protocol_version = (client_protocol_version[0] * 10) + client_protocol_version[1];
+    conn->client_protocol_version = MIN((client_protocol_version[0] * 10) + client_protocol_version[1], S2N_TLS12);
     conn->client_hello_version = conn->client_protocol_version;
     /* Protocol version in the ClientHello is fixed at 0x0303(TLS 1.2) for
      * future versions of TLS. Still, we will negotiate down if a client sends
      * an unexpected value above 0x0303.
      */
-    conn->actual_protocol_version = MIN(conn->client_protocol_version, conn->server_protocol_version);
+    if (conn->server_protocol_version < S2N_TLS13)
+    {
+        conn->actual_protocol_version = MIN(conn->client_protocol_version, conn->server_protocol_version);
+    } 
 
     S2N_ERROR_IF(conn->session_id_len > S2N_TLS_SESSION_ID_MAX_LEN || conn->session_id_len > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
 


### PR DESCRIPTION
Mirror of awslabs s2n#1501


**Issue # (if available):** 
#1415
**Description of changes:** 
- In tls13 the client protocol version is sent in the extensions. Thus if the client sends a protocol version that is greater than tls12 NOT in extensions, the client protocol version will be set to tls12 because its probably a bug. 
- Additionally, if there is no possibility of a tls13 connection, actual_protocol_version is set to the minimum version between server and client, but if there is a possibility of a tls13 connection, actual_protocol_version will remain at 0 until the extensions are parsed.
- Also fixed minor grammar mistake in a test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

