### PR TITLE
Mirror of awslabs s2n#1500

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -75,7 +75,7 @@ extern int s2n_config_set_monotonic_clock(struct s2n_config *config, s2n_clock_t
 
 extern const char *s2n_strerror(int error, const char *lang);
 extern const char *s2n_strerror_debug(int error, const char *lang);
-extern const char *s2n_strerror_name(int error); 
+extern const char *s2n_strerror_name(int error);
 
 struct s2n_stacktrace;
 extern bool s2n_stack_traces_enabled(void);

--- a/tests/unit/s2n_cipher_preference_test.c
+++ b/tests/unit/s2n_cipher_preference_test.c
@@ -14,8 +14,13 @@
  */
 
 #include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include <s2n.h>
 
 #include "tls/s2n_cipher_preferences.h"
+#include "tls/s2n_tls.h"
+#include "tls/s2n_tls13.h"
 
 int main(int argc, char **argv)
 {
@@ -80,6 +85,33 @@ int main(int argc, char **argv)
         preferences = &fake_preferences;
         EXPECT_FAILURE(s2n_ecc_extension_required(preferences));
         EXPECT_FAILURE(s2n_pq_kem_extension_required(preferences));
+    }
+
+    /* Test minimum protocol version update works on config */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+
+        EXPECT_FAILURE(s2n_config_set_min_protocol_version(config, "S2N_SSLv3"));
+        EXPECT_SUCCESS(s2n_config_set_min_protocol_version(config, "S2N_TLS12"));
+
+        EXPECT_EQUAL(config->minimum_protocol_version, S2N_TLS12);
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Test minimum protocol version update works with tls13 enabled/disabled */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+
+        EXPECT_SUCCESS(s2n_disable_tls13());
+        EXPECT_FAILURE(s2n_config_set_min_protocol_version(config, "S2N_TLS13"));
+
+        EXPECT_SUCCESS(s2n_enable_tls13());
+        EXPECT_SUCCESS(s2n_config_set_min_protocol_version(config, "S2N_TLS13"));
+
+        EXPECT_EQUAL(config->minimum_protocol_version, S2N_TLS13);
+        EXPECT_SUCCESS(s2n_config_free(config));
     }
 
     END_TEST();

--- a/tls/extensions/s2n_supported_versions.c
+++ b/tls/extensions/s2n_supported_versions.c
@@ -21,11 +21,16 @@
 
 #include "utils/s2n_safety.h"
 
-int s2n_connection_get_minimum_supported_version(struct s2n_connection *conn, uint8_t *min_version) 
+int s2n_connection_get_minimum_supported_version(struct s2n_connection *conn, uint8_t *min_version)
 {
-    const struct s2n_cipher_preferences *cipher_preferences;
-    GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
-    *min_version = cipher_preferences->minimum_protocol_version;
+    notnull_check(conn);
+    notnull_check(min_version);
+
+    if (conn->cipher_pref_override != NULL) {
+        *min_version = conn->cipher_pref_override->minimum_protocol_version;
+    } else {
+        *min_version = conn->config->minimum_protocol_version;
+    }
 
     return 0;
 }

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -25,6 +25,8 @@ struct s2n_cipher_preferences {
     int minimum_protocol_version;
 };
 
+extern uint8_t s2n_highest_protocol_version;
+
 extern const struct s2n_cipher_preferences cipher_preferences_20140601;
 extern const struct s2n_cipher_preferences cipher_preferences_20141001;
 extern const struct s2n_cipher_preferences cipher_preferences_20150202;
@@ -59,5 +61,6 @@ extern const struct s2n_cipher_preferences elb_security_policy_fs_1_2_res_2019_0
 extern int s2n_cipher_preferences_init();
 extern int s2n_find_cipher_pref_from_version(const char *version, const struct s2n_cipher_preferences **cipher_preferences);
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);
+extern int s2n_config_set_min_protocol_version(struct s2n_config *config, const char *version);
 extern int s2n_ecc_extension_required(const struct s2n_cipher_preferences *preferences);
 extern int s2n_pq_kem_extension_required(const struct s2n_cipher_preferences *preferences);

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -40,6 +40,8 @@
 #include "utils/s2n_random.h"
 #include "utils/s2n_safety.h"
 
+#include "tls/extensions/s2n_supported_versions.h"
+
 typedef char s2n_tls_extension_mask[8192];
 
 static s2n_tls_extension_mask s2n_suported_extensions = { 0 };
@@ -297,10 +299,10 @@ int s2n_process_client_hello(struct s2n_connection *conn)
         GUARD(s2n_client_extensions_recv(conn, client_hello->parsed_extensions));
     }
 
-    const struct s2n_cipher_preferences *cipher_preferences;
-    GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+    uint8_t minimum_protocol_version;
+    GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_protocol_version));
 
-    if (conn->client_protocol_version < cipher_preferences->minimum_protocol_version) {
+    if (conn->client_protocol_version < minimum_protocol_version) {
         GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
         S2N_ERROR(S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
     }
@@ -442,10 +444,10 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     uint16_t challenge_length;
     uint8_t *cipher_suites;
 
-    const struct s2n_cipher_preferences *cipher_preferences;
-    GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+    uint8_t minimum_protocol_version;
+    GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_protocol_version));
 
-    if (conn->client_protocol_version < cipher_preferences->minimum_protocol_version) {
+    if (conn->client_protocol_version < minimum_protocol_version) {
         GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
         S2N_ERROR(S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
     }

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -117,6 +117,7 @@ static int s2n_config_init(struct s2n_config *config)
     config->cert_tiebreak_cb = NULL;
 
     s2n_config_set_cipher_preferences(config, "default");
+    config->minimum_protocol_version = config->cipher_preferences->minimum_protocol_version;
 
     if (s2n_is_in_fips_mode()) {
         s2n_config_set_cipher_preferences(config, "default_fips");

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -33,7 +33,7 @@ struct s2n_cipher_preferences;
 struct s2n_config {
     struct s2n_dh_params *dhparams;
     /* Needed until we can deprecate s2n_config_add_cert_chain_and_key. This is
-     * used to release memory allocated only in the deprecated API that the application 
+     * used to release memory allocated only in the deprecated API that the application
      * does not have a reference to. */
     unsigned cert_allocated:1;
     struct s2n_map *domain_name_to_cert_map;
@@ -93,6 +93,10 @@ struct s2n_config {
     uint8_t disable_x509_validation;
     uint16_t max_verify_cert_chain_depth;
     uint8_t max_verify_cert_chain_depth_set;
+
+    /* Minimum supported TLS protocol version. This is initiated according to attached
+     * cipher_preferences but can be updated by s2n_config_set_min_protocol_version. */
+    uint8_t minimum_protocol_version;
 };
 
 extern struct s2n_config *s2n_fetch_default_config(void);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -91,14 +91,14 @@ static int s2n_connection_init_hashes(struct s2n_connection *conn)
     if (s2n_is_in_fips_mode()) {
         GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.md5));
         GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.prf_md5_hash_copy));
-        
-        /* Do not check s2n_hash_is_available before initialization. Allow MD5 and 
+
+        /* Do not check s2n_hash_is_available before initialization. Allow MD5 and
          * SHA-1 for both fips and non-fips mode. This is required to perform the
-         * signature checks in the CertificateVerify message in TLS 1.0 and TLS 1.1. 
+         * signature checks in the CertificateVerify message in TLS 1.0 and TLS 1.1.
          * This is approved per Nist SP 800-52r1.*/
         GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.md5_sha1));
     }
-    
+
     GUARD(s2n_hash_init(&conn->handshake.md5, S2N_HASH_MD5));
     GUARD(s2n_hash_init(&conn->handshake.prf_md5_hash_copy, S2N_HASH_MD5));
     GUARD(s2n_hash_init(&conn->handshake.md5_sha1, S2N_HASH_MD5_SHA1));
@@ -748,7 +748,7 @@ int s2n_connection_get_cipher_preferences(struct s2n_connection *conn, const str
     notnull_check(conn);
     notnull_check(cipher_preferences);
 
-    if(conn->cipher_pref_override != NULL) {
+    if (conn->cipher_pref_override != NULL) {
         *cipher_preferences = conn->cipher_pref_override;
     } else {
         *cipher_preferences = conn->config->cipher_preferences;
@@ -1213,4 +1213,3 @@ struct s2n_cert_chain_and_key *s2n_connection_get_selected_cert(struct s2n_conne
     notnull_check_ptr(conn);
     return conn->handshake_params.our_chain_and_key;
 }
-

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -206,8 +206,8 @@ struct s2n_connection {
      */
     uint16_t max_outgoing_fragment_length;
 
-    /* The number of bytes to send before changing the record size. 
-     * If this value > 0 then dynamic TLS record size is enabled. Otherwise, the feature is disabled (default). 
+    /* The number of bytes to send before changing the record size.
+     * If this value > 0 then dynamic TLS record size is enabled. Otherwise, the feature is disabled (default).
      */
     uint32_t dynamic_record_resize_threshold;
 

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -34,6 +34,8 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_random.h"
 
+#include "tls/extensions/s2n_supported_versions.h"
+
 /* From RFC5246 7.4.1.2. */
 #define S2N_TLS_COMPRESSION_METHOD_NULL 0
 
@@ -140,10 +142,10 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
 
         S2N_ERROR_IF(s2n_client_detect_downgrade_mechanism(conn), S2N_ERR_PROTOCOL_DOWNGRADE_DETECTED);
 
-        const struct s2n_cipher_preferences *cipher_preferences;
-        GUARD(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+        uint8_t minimum_protocol_version;
+        GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_protocol_version));
 
-        if (conn->server_protocol_version < cipher_preferences->minimum_protocol_version
+        if (conn->server_protocol_version < minimum_protocol_version
                 || conn->server_protocol_version > conn->client_protocol_version) {
             GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
             S2N_ERROR(S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);


### PR DESCRIPTION
Mirror of awslabs s2n#1500
**Issue # (if available):** 
Add functionality to specify minimum protocol version.

The current plan is to give struct s2n_config a dedicated param to specify min version.

**So on config level, we have logic:**
When new function s2n_config_set_min_protocol_version() is called onto a config, and only when the input version is higher than the config's cipher preferences' default TLS version, the param will be overrode.

When s2n_config_set_cipher_preferences() is called onto a config, then its min version will be set back to the new cipher preferences' default TLS version.

**On connection level, we have logic:**
We don't specify another override version param for each single connection.
Each connection only reads min version according to:
Does it have connection-layer overrode cipher preference?
    If so, then use the cipher preference's default version
Else:
    Then use its config's min version, as mentioned above.

We don't add another override version param for each connection because it will add too much nested logic, add unnecessary complexity and we don't see any demands for it so far.

**Description of changes:** 
Add minimum_protocol_version param for struct s2n_config;
Add API int s2n_config_set_min_protocol_version(struct s2n_config *config, const char *version);
Change the way how we read a connection's current minimum TLS version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

