### PR TITLE
Mirror of awslabs s2n#1499

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -926,6 +926,9 @@ Initially *value_size will be set to the amount of space allocated for
 the value, the callback should set *value_size to the actual size of the
 data returned. If there is insufficient space, -1 should be returned.
 
+If the cache is not ready to provide data for the request, S2N_ERR_CACHE_WILL_BLOCK should be returned.
+This will cause s2n_negotiate() to return S2N_BLOCKED_ON_READ.
+
 ### s2n\_config\_set\_cache\_delete\_callback
 
 ```c

--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -35,6 +35,8 @@
 #define S2N_ERR_T_INTERNAL_START (S2N_ERR_T_INTERNAL << S2N_ERR_NUM_VALUE_BITS)
 #define S2N_ERR_T_USAGE_START (S2N_ERR_T_USAGE << S2N_ERR_NUM_VALUE_BITS)
 
+#define S2N_ERR_CACHE_WILL_BLOCK -2
+
 /* Order of values in this enum is important. New error values should be placed at the end of their respective category.
  * For example, a new TLS protocol related error belongs in the S2N_ERR_T_PROTO category. It should be placed
  * immediately before S2N_ERR_T_INTERNAL_START(the first value of he next category).

--- a/tests/unit/s2n_session_cache_async_test.c
+++ b/tests/unit/s2n_session_cache_async_test.c
@@ -80,7 +80,7 @@ int cache_retrieve(struct s2n_connection *conn, void *ctx, const void *key, uint
          * state machine, until lock is free
          */
         cache[index].lock = 0;
-        return -2;
+        return S2N_ERR_CACHE_WILL_BLOCK;
     }
 
     if (cache[index].key_len != key_size) {
@@ -340,7 +340,7 @@ int main(int argc, char **argv)
          * connection/event from the lock
          */
         EXPECT_EQUAL(r, -1);
-        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_APPLICATION_INPUT);
+        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
         s2n_errno = S2N_ERR_T_OK;
         EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
 
@@ -378,7 +378,7 @@ int main(int argc, char **argv)
          * connection/event from the lock
          */
         EXPECT_EQUAL(r, -1);
-        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_APPLICATION_INPUT);
+        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
         s2n_errno = S2N_ERR_T_OK;
         EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
 

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -274,19 +274,7 @@ static int s2n_populate_client_hello_extensions(struct s2n_client_hello *ch)
 
     return 0;
 }
-int s2n_handshake_status_handler(struct s2n_connection *conn)
-{
-    /* Set the handshake type */
-    GUARD(s2n_conn_set_handshake_type(conn));
 
-    if(conn->client_hello_version != S2N_SSLv2)
-    {
-        /* We've selected the parameters for the handshake, update the required hashes for this connection */
-        GUARD(s2n_conn_update_required_handshake_hashes(conn));
-    }
-
-    return 0;
-}
 int s2n_process_client_hello(struct s2n_connection *conn)
 {
     /* Client hello is parsed and config is finalized.
@@ -341,15 +329,6 @@ int s2n_client_hello_recv(struct s2n_connection *conn)
         }
     }
     GUARD(s2n_process_client_hello(conn));
-
-    /* s2n_conn_set_handshake_type() is called by SERVER_SESSION_LOOKUP in < TLS 1.3,
-     * which is something not present in the current s2n tls 1.3 state machine.
-     * we call this manually so the state machine can transition to the
-     * negotiated and handshake type for tls1.3
-     */
-    if (conn->actual_protocol_version == S2N_TLS13) {
-        GUARD(s2n_conn_set_handshake_type(conn));
-    }
 
     return 0;
 }

--- a/tls/s2n_establish_session.c
+++ b/tls/s2n_establish_session.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <stdint.h>
+#include <s2n.h>
+
+#include "error/s2n_errno.h"
+
+#include "stuffer/s2n_stuffer.h"
+
+#include "tls/s2n_connection.h"
+#include "tls/s2n_tls.h"
+
+#include "utils/s2n_array.h"
+
+
+/* Establishing a session requires reading the CLIENT_HELLO message and then generating security parameters.
+ *
+ * S2N supports resuming sessions under TLS1.2 if the client sends a session ID. The server can lookup a
+ * provided session ID in its cache. */
+int s2n_establish_session(struct s2n_connection *conn)
+{
+    GUARD(s2n_conn_set_handshake_read_block(conn));
+
+    /* Start by receiving and processing the entire CLIENT_HELLO message */
+    if (!conn->handshake.client_hello_finished) {
+        GUARD(s2n_client_hello_recv(conn));
+        conn->handshake.client_hello_finished = 1;
+    }
+
+    /* Next negotiate session security parameters. These could be generated, or retrieved from a cache
+     * based on the client's session id. This step uses data obtained from the CLIENT_HELLO message,
+     * which is why we process it here.
+     * This function won't block, it will fail and set s2n_errno accordingly. */
+    GUARD(s2n_conn_set_handshake_type(conn));
+
+    if(conn->client_hello_version != S2N_SSLv2)
+    {
+        /* We've selected the parameters for the handshake, update the required hashes for this connection */
+        GUARD(s2n_conn_update_required_handshake_hashes(conn));
+    }
+
+    GUARD(s2n_conn_clear_handshake_read_block(conn));
+
+    return 0;
+}
+

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -30,7 +30,6 @@
 /* This is the list of message types that we support */
 typedef enum {
     CLIENT_HELLO=0,
-    SERVER_SESSION_LOOKUP,
     SERVER_HELLO,
     SERVER_CERT,
     SERVER_NEW_SESSION_TICKET,
@@ -119,6 +118,12 @@ struct s2n_handshake {
     uint8_t server_finished[S2N_TLS_SECRET_LEN];
     uint8_t client_finished[S2N_TLS_SECRET_LEN];
 
+    /* Indicates the CLIENT_HELLO message has been completely processed */
+    uint8_t client_hello_finished;
+
+    /* Indicates the handshake blocked while trying to read data */
+    uint8_t blocked_on_read;
+
     /* Handshake type is a bitset, with the following
        bit positions */
     uint32_t handshake_type;
@@ -160,6 +165,8 @@ struct s2n_handshake {
 extern message_type_t s2n_conn_get_current_message_type(struct s2n_connection *conn);
 extern int s2n_conn_set_handshake_type(struct s2n_connection *conn);
 extern int s2n_conn_set_handshake_no_client_cert(struct s2n_connection *conn);
+extern int s2n_conn_set_handshake_read_block(struct s2n_connection *conn);
+extern int s2n_conn_clear_handshake_read_block(struct s2n_connection *conn);
 extern int s2n_handshake_require_all_hashes(struct s2n_handshake *handshake);
 extern uint8_t s2n_handshake_is_hash_required(struct s2n_handshake *handshake, s2n_hash_algorithm hash_alg);
 extern int s2n_conn_update_required_handshake_hashes(struct s2n_connection *conn);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -58,23 +58,16 @@
 struct s2n_handshake_action {
     uint8_t record_type;
     uint8_t message_type;
-    char writer;                /* 'S' or 'C' for server or client, 'B' for both, 'A' for application data */
+    char writer;                /* 'S' or 'C' for server or client, 'B' for both */
     int (*handler[2]) (struct s2n_connection * conn);
 };
-
-static int s2n_handshake_dummy_handler(struct s2n_connection *conn) {
-    /* This handler is just to advance the state machine, 
-     * which can be used in some cases such as application data handling */
-    return 0;
-}
 
 /* Client and Server handlers for each message type we support.  
  * See http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-7 for the list of handshake message types
  */
 static struct s2n_handshake_action state_machine[] = {
     /* message_type_t           = {Record type   Message type     Writer S2N_SERVER                S2N_CLIENT }  */
-    [CLIENT_HELLO]              = {TLS_HANDSHAKE, TLS_CLIENT_HELLO, 'C', {s2n_client_hello_recv, s2n_client_hello_send}},
-    [SERVER_SESSION_LOOKUP]     = {TLS_HANDSHAKE, TLS_SERVER_SESSION_LOOKUP, 'A', {s2n_handshake_status_handler, s2n_handshake_dummy_handler}},
+    [CLIENT_HELLO]              = {TLS_HANDSHAKE, TLS_CLIENT_HELLO, 'C', {s2n_establish_session, s2n_client_hello_send}},
     [SERVER_HELLO]              = {TLS_HANDSHAKE, TLS_SERVER_HELLO, 'S', {s2n_server_hello_send, s2n_server_hello_recv}},
     [SERVER_NEW_SESSION_TICKET] = {TLS_HANDSHAKE, TLS_SERVER_NEW_SESSION_TICKET,'S', {s2n_server_nst_send, s2n_server_nst_recv}},
     [SERVER_CERT]               = {TLS_HANDSHAKE, TLS_CERTIFICATE, 'S', {s2n_server_cert_send, s2n_server_cert_recv}},
@@ -97,8 +90,7 @@ static struct s2n_handshake_action state_machine[] = {
  */
 static struct s2n_handshake_action tls13_state_machine[] = {
     /* message_type_t           = {Record type, Message type, Writer, {Server handler, client handler} }  */
-    [CLIENT_HELLO]              = {TLS_HANDSHAKE, TLS_CLIENT_HELLO, 'C', {s2n_client_hello_recv, s2n_client_hello_send}},
-
+    [CLIENT_HELLO]              = {TLS_HANDSHAKE, TLS_CLIENT_HELLO, 'C', {s2n_establish_session, s2n_client_hello_send}},
     [SERVER_HELLO]              = {TLS_HANDSHAKE, TLS_SERVER_HELLO, 'S', {s2n_server_hello_send, s2n_server_hello_recv}},
     [ENCRYPTED_EXTENSIONS]      = {TLS_HANDSHAKE, TLS_ENCRYPTED_EXTENSIONS, 'S', {s2n_encrypted_extensions_send, s2n_encrypted_extensions_recv}},
     [SERVER_CERT_REQ]           = {TLS_HANDSHAKE, TLS_CERT_REQ, 'S', {s2n_client_cert_req_send, s2n_client_cert_req_recv}},
@@ -121,7 +113,6 @@ static struct s2n_handshake_action tls13_state_machine[] = {
 
 static const char *message_names[] = {
     MESSAGE_NAME_ENTRY(CLIENT_HELLO),
-    MESSAGE_NAME_ENTRY(SERVER_SESSION_LOOKUP),
     MESSAGE_NAME_ENTRY(SERVER_HELLO),
     MESSAGE_NAME_ENTRY(ENCRYPTED_EXTENSIONS),
     MESSAGE_NAME_ENTRY(SERVER_NEW_SESSION_TICKET),
@@ -154,25 +145,24 @@ static const char *message_names[] = {
 static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH] = {
     [INITIAL] = {
             CLIENT_HELLO,
-            SERVER_SESSION_LOOKUP,
             SERVER_HELLO
     },
 
     [NEGOTIATED] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
             CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             APPLICATION_DATA
     },
 
     [NEGOTIATED | WITH_SESSION_TICKET ] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_NEW_SESSION_TICKET, SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
             CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             APPLICATION_DATA},
 
     [NEGOTIATED | FULL_HANDSHAKE ] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_HELLO_DONE,
             CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -180,7 +170,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | WITH_SESSION_TICKET ] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_HELLO_DONE,
             CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_NEW_SESSION_TICKET, SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -188,7 +178,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY ] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_KEY, SERVER_HELLO_DONE,
             CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -196,7 +186,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | WITH_SESSION_TICKET ] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_KEY, SERVER_HELLO_DONE,
             CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_NEW_SESSION_TICKET, SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -204,7 +194,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | OCSP_STATUS ] ={
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_HELLO_DONE,
             CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -212,7 +202,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | OCSP_STATUS | WITH_SESSION_TICKET ] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_HELLO_DONE,
             CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_NEW_SESSION_TICKET, SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -220,7 +210,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | OCSP_STATUS ] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_KEY, SERVER_HELLO_DONE,
             CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -228,7 +218,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | OCSP_STATUS  | WITH_SESSION_TICKET ] ={
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_KEY, SERVER_HELLO_DONE,
             CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_NEW_SESSION_TICKET, SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -236,7 +226,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_REQ, SERVER_HELLO_DONE,
             CLIENT_CERT, CLIENT_KEY, CLIENT_CERT_VERIFY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -244,7 +234,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | NO_CLIENT_CERT ] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_REQ, SERVER_HELLO_DONE,
             CLIENT_CERT, CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -252,7 +242,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | WITH_SESSION_TICKET] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_REQ, SERVER_HELLO_DONE,
             CLIENT_CERT, CLIENT_KEY, CLIENT_CERT_VERIFY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_NEW_SESSION_TICKET, SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -260,7 +250,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | NO_CLIENT_CERT | WITH_SESSION_TICKET ] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_REQ, SERVER_HELLO_DONE,
             CLIENT_CERT, CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_NEW_SESSION_TICKET, SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -268,7 +258,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | CLIENT_AUTH] = {
-           CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+           CLIENT_HELLO,
            SERVER_HELLO, SERVER_CERT, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
            CLIENT_CERT, CLIENT_KEY, CLIENT_CERT_VERIFY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
            SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -276,7 +266,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | CLIENT_AUTH | NO_CLIENT_CERT ] = {
-           CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+           CLIENT_HELLO,
            SERVER_HELLO, SERVER_CERT, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
            CLIENT_CERT, CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
            SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -284,7 +274,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | CLIENT_AUTH | WITH_SESSION_TICKET] = {
-           CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+           CLIENT_HELLO,
            SERVER_HELLO, SERVER_CERT, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
            CLIENT_CERT, CLIENT_KEY, CLIENT_CERT_VERIFY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
            SERVER_NEW_SESSION_TICKET, SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -292,7 +282,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | CLIENT_AUTH | NO_CLIENT_CERT | WITH_SESSION_TICKET ] = {
-           CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+           CLIENT_HELLO,
            SERVER_HELLO, SERVER_CERT, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
            CLIENT_CERT, CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
            SERVER_NEW_SESSION_TICKET, SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -300,7 +290,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | OCSP_STATUS | CLIENT_AUTH] = {
-           CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+           CLIENT_HELLO,
            SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_CERT_REQ, SERVER_HELLO_DONE,
            CLIENT_CERT, CLIENT_KEY, CLIENT_CERT_VERIFY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
            SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -308,7 +298,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | OCSP_STATUS | CLIENT_AUTH | NO_CLIENT_CERT ] = {
-           CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+           CLIENT_HELLO,
            SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_CERT_REQ, SERVER_HELLO_DONE,
            CLIENT_CERT, CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
            SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -316,7 +306,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | OCSP_STATUS | CLIENT_AUTH | WITH_SESSION_TICKET] = {
-           CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+           CLIENT_HELLO,
            SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_CERT_REQ, SERVER_HELLO_DONE,
            CLIENT_CERT, CLIENT_KEY, CLIENT_CERT_VERIFY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
            SERVER_NEW_SESSION_TICKET, SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -324,7 +314,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | OCSP_STATUS | CLIENT_AUTH | NO_CLIENT_CERT | WITH_SESSION_TICKET ] = {
-           CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+           CLIENT_HELLO,
            SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_CERT_REQ, SERVER_HELLO_DONE,
            CLIENT_CERT, CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
            SERVER_NEW_SESSION_TICKET, SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -332,7 +322,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | OCSP_STATUS | CLIENT_AUTH ] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
             CLIENT_CERT, CLIENT_KEY, CLIENT_CERT_VERIFY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -340,7 +330,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | OCSP_STATUS | CLIENT_AUTH | NO_CLIENT_CERT ] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
             CLIENT_CERT, CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -348,7 +338,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | OCSP_STATUS | CLIENT_AUTH | WITH_SESSION_TICKET ] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
             CLIENT_CERT, CLIENT_KEY, CLIENT_CERT_VERIFY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_NEW_SESSION_TICKET, SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -356,7 +346,7 @@ static message_type_t handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_LENGTH]
     },
 
     [NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | OCSP_STATUS | CLIENT_AUTH | NO_CLIENT_CERT | WITH_SESSION_TICKET ] = {
-            CLIENT_HELLO, SERVER_SESSION_LOOKUP,
+            CLIENT_HELLO,
             SERVER_HELLO, SERVER_CERT, SERVER_CERT_STATUS, SERVER_KEY, SERVER_CERT_REQ, SERVER_HELLO_DONE,
             CLIENT_CERT, CLIENT_KEY, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
             SERVER_NEW_SESSION_TICKET, SERVER_CHANGE_CIPHER_SPEC, SERVER_FINISHED,
@@ -517,7 +507,7 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
 
     /* If a TLS session is resumed, the Server should respond in its ServerHello with the same SessionId the
      * Client sent in the ClientHello. */
-    if (conn->mode == S2N_SERVER && s2n_allowed_to_cache_connection(conn)) {
+    if (conn->server_protocol_version <= S2N_TLS12 && conn->mode == S2N_SERVER && s2n_allowed_to_cache_connection(conn)) {
         int r = s2n_resume_from_cache(conn);
         if (r == S2N_SUCCESS || (r < 0 && s2n_errno == S2N_ERR_BLOCKED)) {
             return r;
@@ -564,6 +554,22 @@ int s2n_conn_set_handshake_no_client_cert(struct s2n_connection *conn)
     S2N_ERROR_IF(client_cert_auth_type != S2N_CERT_AUTH_OPTIONAL, S2N_ERR_BAD_MESSAGE);
 
     conn->handshake.handshake_type |= NO_CLIENT_CERT;
+    return 0;
+}
+
+int s2n_conn_set_handshake_read_block(struct s2n_connection *conn)
+{
+    notnull_check(conn);
+
+    conn->handshake.blocked_on_read = 1;
+    return 0;
+}
+
+int s2n_conn_clear_handshake_read_block(struct s2n_connection *conn)
+{
+    notnull_check(conn);
+
+    conn->handshake.blocked_on_read = 0;
     return 0;
 }
 
@@ -854,36 +860,10 @@ static int s2n_handshake_handle_sslv2(struct s2n_connection *conn)
     return 0;
 }
 
-/* Sometimes the handshake state machine can be blocked on application data. 
- * For example, if the s2n server is using a remote upstream peer for session cache lookup,
- * the handshake state machine will be blocked until there is data returned from the 
- * session cache server. In such a case, there is no data in the underlying io, 
- * so we can just call the corresponding handler to process the application data.
- * Note that we need a return value -2 to indicate that app data is not yet avaiable 
- * and the state machine is still blocked; a return value 0 to indicate the app data is 
- * successfully processed and state machine advanced; -1 to indicate an error and 
- * the connection been killed
- */
-static int s2n_handshake_handle_app_data(struct s2n_connection *conn) {
-    int r = ACTIVE_STATE(conn).handler[conn->mode] (conn);
-
-    if (r == S2N_SUCCESS) {
-        /* if r == 0, then we advance the state machine */
-        GUARD(s2n_stuffer_wipe(&conn->handshake.io));
-        GUARD(s2n_advance_message(conn));
-        goto done;
-    }
-
-    if (r < 0) {
-        if(s2n_errno != S2N_ERR_BLOCKED) {
-            GUARD(s2n_stuffer_wipe(&conn->handshake.io));
-            GUARD(s2n_connection_kill(conn));
-        }
-        return r;
-    }
-
-done:
-    conn->in_status = ENCRYPTED;
+static int s2n_try_delete_session_cache(struct s2n_connection *conn)
+{
+    notnull_check(conn);
+    conn->config->cache_delete(conn, conn->config->cache_delete_data, conn->session_id, conn->session_id_len);
 
     return 0;
 }
@@ -1003,6 +983,10 @@ static int handshake_read_io(struct s2n_connection *conn)
                 case S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED:
                     conn->closed = 1;
                     break;
+                case S2N_ERR_BLOCKED:
+                    /* A blocking condition is retryable, so we should return without killing the connection. */
+                    S2N_ERROR_PRESERVE_ERRNO();
+                    break;
                 default:
                     GUARD(s2n_connection_kill(conn));
             }
@@ -1022,15 +1006,6 @@ static int handshake_read_io(struct s2n_connection *conn)
     return 0;
 }
 
-static int s2n_try_delete_session_cache(struct s2n_connection *conn) 
-{
-    notnull_check(conn);
-    if (s2n_errno != S2N_ERR_BLOCKED && s2n_allowed_to_cache_connection(conn) && conn->session_id_len) {
-        conn->config->cache_delete(conn, conn->config->cache_delete_data, conn->session_id, conn->session_id_len);
-    }
-    return 0;
-}
-
 int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status * blocked)
 {
     errno = 0;
@@ -1040,27 +1015,41 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status * blocked)
         this = 'C';
     }
 
+    /* If we were blocked reading a record, call the handler right away. Don't try to read more data. */
+    if (conn->handshake.blocked_on_read) {
+        int r = ACTIVE_STATE(conn).handler[conn->mode] (conn);
+
+        if (r < 0) {
+            /* If we are still blocked, return control to the caller. */
+            if (s2n_errno == S2N_ERR_BLOCKED) {
+                S2N_ERROR_PRESERVE_ERRNO();
+            }
+
+            /* Otherwise there is some other problem and we should kill the connection. */
+            if (s2n_allowed_to_cache_connection(conn) && conn->session_id_len) {
+                s2n_try_delete_session_cache(conn);
+            }
+
+            GUARD(s2n_connection_kill(conn));
+            S2N_ERROR_PRESERVE_ERRNO();
+        }
+
+        /* The handler completed successfully, we are done with this record. */
+        /* Advance the state machine and wipe the record. */
+        GUARD(s2n_advance_message(conn));
+
+        GUARD(s2n_stuffer_wipe(&conn->header_in));
+        GUARD(s2n_stuffer_wipe(&conn->in));
+        conn->in_status = ENCRYPTED;
+    }
+
     while (ACTIVE_STATE(conn).writer != 'B') {
+        s2n_errno = S2N_ERR_T_OK;
+
         /* Flush any pending I/O or alert messages */
         GUARD(s2n_flush(conn, blocked));
 
-        if (ACTIVE_STATE(conn).writer == 'A') {
-            /* We are in a state that is blocked on application data */
-            *blocked = S2N_BLOCKED_ON_APPLICATION_INPUT;
-
-            int r = s2n_handshake_handle_app_data(conn);
-            if (r < 0) {
-                s2n_try_delete_session_cache(conn);
-                /* The peer might have sent an alert. Try and read it. */
-                if (s2n_errno == S2N_ERR_BLOCKED && s2n_stuffer_data_available(&conn->in)) {
-                    if (handshake_read_io(conn) < 0 && s2n_errno == S2N_ERR_ALERT) {
-                        /* handshake_read_io has set s2n_errno */
-                        S2N_ERROR_PRESERVE_ERRNO();
-                    }
-                }
-                S2N_ERROR_PRESERVE_ERRNO();
-            }
-        } else if (ACTIVE_STATE(conn).writer == this) {
+        if (ACTIVE_STATE(conn).writer == this) {
             *blocked = S2N_BLOCKED_ON_WRITE;
             if (handshake_write_io(conn) < 0 && s2n_errno != S2N_ERR_BLOCKED) {
                 /* Non-retryable write error. The peer might have sent an alert. Try and read it. */
@@ -1081,10 +1070,16 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status * blocked)
             }
         } else {
             *blocked = S2N_BLOCKED_ON_READ;
+
             int r = handshake_read_io(conn);
 
             if (r < 0) {
-                s2n_try_delete_session_cache(conn);
+                /* One blocking condition is waiting on the session resumption cache. */
+                /* So we don't want to delete anything if we are blocked. */
+                if (s2n_errno != S2N_ERR_BLOCKED && s2n_allowed_to_cache_connection(conn) && conn->session_id_len) {
+                    s2n_try_delete_session_cache(conn);
+                }
+
                 S2N_ERROR_PRESERVE_ERRNO();
             }
         }

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -26,7 +26,7 @@ extern uint8_t s2n_highest_protocol_version;
 extern int s2n_flush(struct s2n_connection *conn, s2n_blocked_status * more);
 extern int s2n_client_hello_send(struct s2n_connection *conn);
 extern int s2n_client_hello_recv(struct s2n_connection *conn);
-extern int s2n_handshake_status_handler(struct s2n_connection *conn);
+extern int s2n_establish_session(struct s2n_connection *conn);
 extern int s2n_sslv2_client_hello_recv(struct s2n_connection *conn);
 extern int s2n_server_hello_retry_send(struct s2n_connection *conn);
 extern int s2n_server_hello_retry_recv(struct s2n_connection *conn);

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -99,9 +99,6 @@ static inline void* trace_memcpy_check(void *restrict to, const void *restrict f
 #define GUARD_NONNULL_GOTO( x , label ) do {if ( (x) == NULL ) goto label;} while (0)
 #define GUARD_NONNULL_PTR( x )          do {if ( (x) == NULL ) return NULL;} while (0)
 
-/* Check the return value from caller. If this value is -2, S2N_ERR_BLOCKED is marked*/
-#define GUARD_AGAIN( x )  do {if ( (x) == -2 ) { S2N_ERROR(S2N_ERR_BLOCKED); } GUARD( x );} while(0)
-
 /* Returns true if s2n is in unit test mode, false otherwise */
 bool s2n_in_unit_test();
 


### PR DESCRIPTION
Mirror of awslabs s2n#1499
**Issue # (if available):** #1478

*tl;dr*
We need a way to provide the non-blocking session resumption that customer's require. At the same time, we want to reduce complexity in our state machine and formal testing. Getting this right will cause the tls1.3=>tls1.2 problem to disappear.

**Revised problem statement:**
The S2N TLS1.3 client was failing to connect to TLS1.2 servers. This happened because of an extra state in the TLS1.2 handshake called SERVER_SESSION_LOOKUP, which was not part of the TLS1.3 state machine. This caused an off-by-one error between the "next message received" and the "next message expected" when the client downgraded from TLS1.3 to TLS1.2.

SERVER_SESSION_LOOKUP was added because because customers want S2N to resume sessions, but don't want S2N to block during the handshake waiting on a response from the session cache. The side effects of adding SERVER_SESSION_LOOKUP as a state included:

 * An additional 'A' data handler in the s2n_negotiate loop, which is only used once (or never if session resumption is not enabled).
 * Altering the state machine flow for every handshake type, even if the customer didn't use session resumption.
 * Modifying all formal testing to address this additional state, even though it only occurred under one condition early in the handshake.


**Solution:**
There is an associated PR with WIP code demonstrating a solution that:
 * Removes the additional state from the state machine
 * Continues to allow session resumption in a non-blocking manner

If session resumption is enabled, and the cache lookup would block, we should store the state of the CLIENT_HELLO record and return with the S2N_ERR_BLOCKED message. The caller can retry `s2n_negotiate()` later[0]. When the request is retried, the CLIENT_HELLO record processing will pick up where it left off.


This PR does not update any SAW tests! If this solution is appropriate, then we can update the SAW tests.



[0] I don't know what later means. I'm not sure how the customer currently knows when to resume a handshake blocked on application input.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

